### PR TITLE
3.1 clean errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ Changelog
 
 The revision of GLFW C library used is listed in [GLFW_C_REVISION.txt](GLFW_C_REVISION.txt) file.
 
+* Type <code>glfw3.GLFWError</code> renamed to just <code>glfw3.Error</code>.
 * Method <code>window.SetCharacterCallback</code> renamed to <code>window.SetCharCallback</code>.
 * Method <code>window.SetCharacterModsCallback</code> renamed to <code>window.SetCharModsCallback</code>.
 * Added `Floating` and `AutoIconify` window hints.
 * Easy `go get` installation (GLFW source code included in-repo and compiled in so you don't have to build GLFW on your own first and you don't have to distribute shared libraries).
-* <code>SetErrorCallback</code> This function is removed. The callback is now set internally. Functions return an error with corresponding code and description (do a type assertion to GlfwError for accessing the variables).
+* <code>SetErrorCallback</code> This function is removed. The callback is now set internally. Functions return an error with corresponding code and description (do a type assertion to glfw3.Error for accessing the variables).
 * <code>Init</code> Returns an error instead of bool.
 * <code>GetTime</code> Returns an error.
 * <code>GetCurrentContext</code> No longer returns an error.

--- a/error.go
+++ b/error.go
@@ -11,13 +11,18 @@ import (
 // ErrorCode corresponds to an error code.
 type ErrorCode int
 
+// Error codes that are translated to panics and the programmer should not
+// expect to handle.
+const (
+	notInitialized   ErrorCode = C.GLFW_NOT_INITIALIZED    // GLFW has not been initialized.
+	noCurrentContext ErrorCode = C.GLFW_NO_CURRENT_CONTEXT // No context is current.
+	invalidEnum      ErrorCode = C.GLFW_INVALID_ENUM       // One of the enum parameters for the function was given an invalid enum.
+	invalidValue     ErrorCode = C.GLFW_INVALID_VALUE      // One of the parameters for the function was given an invalid value.
+	outOfMemory      ErrorCode = C.GLFW_OUT_OF_MEMORY      // A memory allocation failed.
+)
+
 // Error codes.
 const (
-	NotInitialized     ErrorCode = C.GLFW_NOT_INITIALIZED     // GLFW has not been initialized.
-	NoCurrentContext   ErrorCode = C.GLFW_NO_CURRENT_CONTEXT  // No context is current.
-	InvalidEnum        ErrorCode = C.GLFW_INVALID_ENUM        // One of the enum parameters for the function was given an invalid enum.
-	InvalidValue       ErrorCode = C.GLFW_INVALID_VALUE       // One of the parameters for the function was given an invalid value.
-	OutOfMemory        ErrorCode = C.GLFW_OUT_OF_MEMORY       // A memory allocation failed.
 	APIUnavailable     ErrorCode = C.GLFW_API_UNAVAILABLE     // GLFW could not find support for the requested client API on the system.
 	VersionUnavailable ErrorCode = C.GLFW_VERSION_UNAVAILABLE // The requested client API version is not available.
 	PlatformError      ErrorCode = C.GLFW_PLATFORM_ERROR      // A platform-specific error occurred that does not match any of the more specific categories.
@@ -76,7 +81,7 @@ func fetchError() error {
 	select {
 	case err := <-lastError:
 		switch err.Code {
-		case OutOfMemory, InvalidEnum, InvalidValue, NotInitialized, NoCurrentContext:
+		case outOfMemory, invalidEnum, invalidValue, notInitialized, noCurrentContext:
 			panic(err)
 		default:
 			return err

--- a/error.go
+++ b/error.go
@@ -75,7 +75,12 @@ func flushErrors() {
 func fetchError() error {
 	select {
 	case err := <-lastError:
-		return err
+		switch err.Code {
+		case OutOfMemory, InvalidEnum, InvalidValue, NotInitialized, NoCurrentContext:
+			panic(err)
+		default:
+			return err
+		}
 	default:
 		return nil
 	}

--- a/error.go
+++ b/error.go
@@ -22,11 +22,49 @@ const (
 	platformError    ErrorCode = C.GLFW_PLATFORM_ERROR     // A platform-specific error occurred that does not match any of the more specific categories.
 )
 
-// Error codes.
 const (
-	APIUnavailable     ErrorCode = C.GLFW_API_UNAVAILABLE     // GLFW could not find support for the requested client API on the system.
-	VersionUnavailable ErrorCode = C.GLFW_VERSION_UNAVAILABLE // The requested client API version is not available.
-	FormatUnavailable  ErrorCode = C.GLFW_FORMAT_UNAVAILABLE  // The clipboard did not contain data in the requested format.
+	// APIUnavailable is the error code used when GLFW could not find support
+	// for the requested client API on the system.
+	//
+	// The installed graphics driver does not support the requested client API,
+	// or does not support it via the chosen context creation backend. Below
+	// are a few examples.
+	//
+	// Some pre-installed Windows graphics drivers do not support OpenGL. AMD
+	// only supports OpenGL ES via EGL, while Nvidia and Intel only supports it
+	// via a WGL or GLX extension. OS X does not provide OpenGL ES at all. The
+	// Mesa EGL, OpenGL and OpenGL ES libraries do not interface with the
+	// Nvidia binary driver.
+	APIUnavailable ErrorCode = C.GLFW_API_UNAVAILABLE
+
+	// VersionUnavailable is the error code used when the requested OpenGL or
+	// OpenGL ES (including any requested profile or context option) is not
+	// available on this machine.
+	//
+	// The machine does not support your requirements. If your application is
+	// sufficiently flexible, downgrade your requirements and try again.
+	// Otherwise, inform the user that their machine does not match your
+	// requirements.
+	//
+	// Future invalid OpenGL and OpenGL ES versions, for example OpenGL 4.8 if
+	// 5.0 comes out before the 4.x series gets that far, also fail with this
+	// error and not GLFW_INVALID_VALUE, because GLFW cannot know what future
+	// versions will exist.
+	VersionUnavailable ErrorCode = C.GLFW_VERSION_UNAVAILABLE
+
+	// FormatUnavailable is the error code used for both window creation and
+	// clipboard querying format errors.
+	//
+	// If emitted during window creation, the requested pixel format is not
+	// supported. This means one or more hard constraints did not match any of
+	// the available pixel formats. If your application is sufficiently
+	// flexible, downgrade your requirements and try again. Otherwise, inform
+	// the user that their machine does not match your requirements.
+	//
+	// If emitted when querying the clipboard, the contents of the clipboard
+	// could not be converted to the requested format. You should ignore the
+	// error or report it to the user, as appropriate.
+	FormatUnavailable ErrorCode = C.GLFW_FORMAT_UNAVAILABLE
 )
 
 func (e ErrorCode) String() string {

--- a/error.go
+++ b/error.go
@@ -29,8 +29,8 @@ const (
 	FormatUnavailable  ErrorCode = C.GLFW_FORMAT_UNAVAILABLE  // The clipboard did not contain data in the requested format.
 )
 
-// GLFWError holds error code and description.
-type GLFWError struct {
+// Error holds error code and description.
+type Error struct {
 	Code ErrorCode
 	Desc string
 }
@@ -39,12 +39,12 @@ type GLFWError struct {
 // See: https://github.com/go-gl/glfw3/pull/86
 
 // Holds the value of the last error.
-var lastError = make(chan *GLFWError, 1)
+var lastError = make(chan *Error, 1)
 
 //export goErrorCB
 func goErrorCB(code C.int, desc *C.char) {
 	flushErrors()
-	err := &GLFWError{ErrorCode(code), C.GoString(desc)}
+	err := &Error{ErrorCode(code), C.GoString(desc)}
 	select {
 	case lastError <- err:
 	default:
@@ -54,7 +54,7 @@ func goErrorCB(code C.int, desc *C.char) {
 }
 
 // Error prints the error code and description in a readable format.
-func (e *GLFWError) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("Error %d: %s", e.Code, e.Desc)
 }
 

--- a/error.go
+++ b/error.go
@@ -106,7 +106,7 @@ func fetchError() error {
 	select {
 	case err := <-lastError:
 		switch err.Code {
-		case outOfMemory, invalidEnum, invalidValue, notInitialized, noCurrentContext:
+		case notInitialized, noCurrentContext, invalidEnum, invalidValue, outOfMemory:
 			panic(err)
 		default:
 			return err

--- a/error.go
+++ b/error.go
@@ -35,6 +35,11 @@ type Error struct {
 	Desc string
 }
 
+// Error prints the error code and description in a readable format.
+func (e *Error) Error() string {
+	return fmt.Sprintf("Error %d: %s", e.Code, e.Desc)
+}
+
 // Note: There are many cryptic caveats to proper error handling here.
 // See: https://github.com/go-gl/glfw3/pull/86
 
@@ -51,11 +56,6 @@ func goErrorCB(code C.int, desc *C.char) {
 		fmt.Println("GLFW: An uncaught error has occurred:", err)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	}
-}
-
-// Error prints the error code and description in a readable format.
-func (e *Error) Error() string {
-	return fmt.Sprintf("Error %d: %s", e.Code, e.Desc)
 }
 
 // Set the glfw callback internally

--- a/error.go
+++ b/error.go
@@ -29,6 +29,31 @@ const (
 	FormatUnavailable  ErrorCode = C.GLFW_FORMAT_UNAVAILABLE  // The clipboard did not contain data in the requested format.
 )
 
+func (e ErrorCode) String() string {
+	switch e {
+	case notInitialized:
+		return "NotInitialized"
+	case noCurrentContext:
+		return "NoCurrentContext"
+	case invalidEnum:
+		return "InvalidEnum"
+	case invalidValue:
+		return "InvalidValue"
+	case outOfMemory:
+		return "OutOfMemory"
+	case APIUnavailable:
+		return "APIUnavailable"
+	case VersionUnavailable:
+		return "VersionUnavailable"
+	case PlatformError:
+		return "PlatformError"
+	case FormatUnavailable:
+		return "FormatUnavailable"
+	default:
+		return fmt.Sprintf("ErrorCode(%d)", e)
+	}
+}
+
 // Error holds error code and description.
 type Error struct {
 	Code ErrorCode
@@ -37,7 +62,7 @@ type Error struct {
 
 // Error prints the error code and description in a readable format.
 func (e *Error) Error() string {
-	return fmt.Sprintf("Error %d: %s", e.Code, e.Desc)
+	return fmt.Sprintf("%s: %s", e.Code.String(), e.Desc)
 }
 
 // Note: There are many cryptic caveats to proper error handling here.

--- a/error.go
+++ b/error.go
@@ -19,13 +19,13 @@ const (
 	invalidEnum      ErrorCode = C.GLFW_INVALID_ENUM       // One of the enum parameters for the function was given an invalid enum.
 	invalidValue     ErrorCode = C.GLFW_INVALID_VALUE      // One of the parameters for the function was given an invalid value.
 	outOfMemory      ErrorCode = C.GLFW_OUT_OF_MEMORY      // A memory allocation failed.
+	platformError    ErrorCode = C.GLFW_PLATFORM_ERROR     // A platform-specific error occurred that does not match any of the more specific categories.
 )
 
 // Error codes.
 const (
 	APIUnavailable     ErrorCode = C.GLFW_API_UNAVAILABLE     // GLFW could not find support for the requested client API on the system.
 	VersionUnavailable ErrorCode = C.GLFW_VERSION_UNAVAILABLE // The requested client API version is not available.
-	PlatformError      ErrorCode = C.GLFW_PLATFORM_ERROR      // A platform-specific error occurred that does not match any of the more specific categories.
 	FormatUnavailable  ErrorCode = C.GLFW_FORMAT_UNAVAILABLE  // The clipboard did not contain data in the requested format.
 )
 
@@ -41,12 +41,12 @@ func (e ErrorCode) String() string {
 		return "InvalidValue"
 	case outOfMemory:
 		return "OutOfMemory"
+	case platformError:
+		return "PlatformError"
 	case APIUnavailable:
 		return "APIUnavailable"
 	case VersionUnavailable:
 		return "VersionUnavailable"
-	case PlatformError:
-		return "PlatformError"
 	case FormatUnavailable:
 		return "FormatUnavailable"
 	default:
@@ -106,7 +106,7 @@ func fetchError() error {
 	select {
 	case err := <-lastError:
 		switch err.Code {
-		case notInitialized, noCurrentContext, invalidEnum, invalidValue, outOfMemory:
+		case notInitialized, noCurrentContext, invalidEnum, invalidValue, outOfMemory, platformError:
 			panic(err)
 		default:
 			return err


### PR DESCRIPTION
This should be my last push for more clean/idiomatic errors from GLFW.

Please see the individual commit descriptions for more information. 

Alternative to #112 (fixed typo in commit message)
