### PR TITLE
Return less errors; Fixes #118

### DIFF
--- a/context.go
+++ b/context.go
@@ -12,32 +12,36 @@ import (
 // Originally GLFW 3 passes a null pointer to detach the context.
 // But since we're using receievers, DetachCurrentContext should
 // be used instead.
-func (w *Window) MakeContextCurrent() error {
+func (w *Window) MakeContextCurrent() {
 	C.glfwMakeContextCurrent(w.data)
-	return fetchError()
+	panicError()
+	return
 }
 
 // DetachCurrentContext detaches the current context.
-func DetachCurrentContext() error {
+func DetachCurrentContext() {
 	C.glfwMakeContextCurrent(nil)
-	return fetchError()
+	panicError()
+	return
 }
 
 // GetCurrentContext returns the window whose context is current.
-func GetCurrentContext() (*Window, error) {
+func GetCurrentContext() *Window {
 	w := C.glfwGetCurrentContext()
+	panicError()
 	if w == nil {
-		return nil, fetchError()
+		return nil
 	}
-	return windows.get(w), nil
+	return windows.get(w)
 }
 
 // SwapBuffers swaps the front and back buffers of the window. If the
 // swap interval is greater than zero, the GPU driver waits the specified number
 // of screen updates before swapping the buffers.
-func (w *Window) SwapBuffers() error {
+func (w *Window) SwapBuffers() {
 	C.glfwSwapBuffers(w.data)
-	return fetchError()
+	panicError()
+	return
 }
 
 // SwapInterval sets the swap interval for the current context, i.e. the number
@@ -54,9 +58,10 @@ func (w *Window) SwapBuffers() error {
 //
 // Some GPU drivers do not honor the requested swap interval, either because of
 // user settings that override the request or due to bugs in the driver.
-func SwapInterval(interval int) error {
+func SwapInterval(interval int) {
 	C.glfwSwapInterval(C.int(interval))
-	return fetchError()
+	panicError()
+	return
 }
 
 // ExtensionSupported returns whether the specified OpenGL or context creation
@@ -67,8 +72,10 @@ func SwapInterval(interval int) error {
 // recommended that you cache its results if it's going to be used frequently.
 // The extension strings will not change during the lifetime of a context, so
 // there is no danger in doing this.
-func ExtensionSupported(extension string) (bool, error) {
+func ExtensionSupported(extension string) bool {
 	e := C.CString(extension)
 	defer C.free(unsafe.Pointer(e))
-	return glfwbool(C.glfwExtensionSupported(e)), fetchError()
+	ret := glfwbool(C.glfwExtensionSupported(e))
+	panicError()
+	return ret
 }

--- a/context.go
+++ b/context.go
@@ -15,14 +15,12 @@ import (
 func (w *Window) MakeContextCurrent() {
 	C.glfwMakeContextCurrent(w.data)
 	panicError()
-	return
 }
 
 // DetachCurrentContext detaches the current context.
 func DetachCurrentContext() {
 	C.glfwMakeContextCurrent(nil)
 	panicError()
-	return
 }
 
 // GetCurrentContext returns the window whose context is current.
@@ -41,7 +39,6 @@ func GetCurrentContext() *Window {
 func (w *Window) SwapBuffers() {
 	C.glfwSwapBuffers(w.data)
 	panicError()
-	return
 }
 
 // SwapInterval sets the swap interval for the current context, i.e. the number
@@ -61,7 +58,6 @@ func (w *Window) SwapBuffers() {
 func SwapInterval(interval int) {
 	C.glfwSwapInterval(C.int(interval))
 	panicError()
-	return
 }
 
 // ExtensionSupported returns whether the specified OpenGL or context creation

--- a/error.go
+++ b/error.go
@@ -163,7 +163,7 @@ func acceptError(codes ...ErrorCode) error {
 	case notInitialized, noCurrentContext, invalidEnum, invalidValue, outOfMemory, platformError:
 		panic(err)
 	default:
-		fmt.Println("GLFW: A invalid error was not accepted by the caller:", err)
+		fmt.Println("GLFW: An invalid error was not accepted by the caller:", err)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 		panic(err)
 	}

--- a/glfw.go
+++ b/glfw.go
@@ -46,7 +46,6 @@ func Init() error {
 func Terminate() {
 	flushErrors()
 	C.glfwTerminate()
-	return
 }
 
 // GetVersion retrieves the major, minor and revision numbers of the GLFW

--- a/glfw.go
+++ b/glfw.go
@@ -30,7 +30,7 @@ const (
 // This function may only be called from the main thread.
 func Init() error {
 	C.glfwInit()
-	return fetchError()
+	return acceptError(APIUnavailable)
 }
 
 // Terminate destroys all remaining windows, frees any allocated resources and
@@ -43,11 +43,10 @@ func Init() error {
 // this function, as it is called by Init before it returns failure.
 //
 // This function may only be called from the main thread.
-func Terminate() error {
-	err := fetchError()
+func Terminate() {
 	flushErrors()
 	C.glfwTerminate()
-	return err
+	return
 }
 
 // GetVersion retrieves the major, minor and revision numbers of the GLFW

--- a/input.go
+++ b/input.go
@@ -303,14 +303,16 @@ func goDropCB(window unsafe.Pointer, count C.int, names **C.char) { // TODO: The
 }
 
 // GetInputMode returns the value of an input option of the window.
-func (w *Window) GetInputMode(mode InputMode) (int, error) {
-	return int(C.glfwGetInputMode(w.data, C.int(mode))), fetchError()
+func (w *Window) GetInputMode(mode InputMode) int {
+	ret := int(C.glfwGetInputMode(w.data, C.int(mode)))
+	panicError()
+	return ret
 }
 
 // Sets an input option for the window.
-func (w *Window) SetInputMode(mode InputMode, value int) error {
+func (w *Window) SetInputMode(mode InputMode, value int) {
 	C.glfwSetInputMode(w.data, C.int(mode), C.int(value))
-	return fetchError()
+	panicError()
 }
 
 // GetKey returns the last reported state of a keyboard key. The returned state
@@ -324,8 +326,10 @@ func (w *Window) SetInputMode(mode InputMode, value int) error {
 // The key functions deal with physical keys, with key tokens named after their
 // use on the standard US keyboard layout. If you want to input text, use the
 // Unicode character callback instead.
-func (w *Window) GetKey(key Key) (Action, error) {
-	return Action(C.glfwGetKey(w.data, C.int(key))), fetchError()
+func (w *Window) GetKey(key Key) Action {
+	ret := Action(C.glfwGetKey(w.data, C.int(key)))
+	panicError()
+	return ret
 }
 
 // GetMouseButton returns the last state reported for the specified mouse button.
@@ -333,8 +337,10 @@ func (w *Window) GetKey(key Key) (Action, error) {
 // If the StickyMouseButtons input mode is enabled, this function returns Press
 // the first time you call this function after a mouse button has been pressed,
 // even if the mouse button has already been released.
-func (w *Window) GetMouseButton(button MouseButton) (Action, error) {
-	return Action(C.glfwGetMouseButton(w.data, C.int(button))), fetchError()
+func (w *Window) GetMouseButton(button MouseButton) Action {
+	ret := Action(C.glfwGetMouseButton(w.data, C.int(button)))
+	panicError()
+	return ret
 }
 
 // GetCursorPos returns the last reported position of the cursor.
@@ -345,10 +351,11 @@ func (w *Window) GetMouseButton(button MouseButton) (Action, error) {
 // The coordinate can be converted to their integer equivalents with the floor
 // function. Casting directly to an integer type works for positive coordinates,
 // but fails for negative ones.
-func (w *Window) GetCursorPos() (x, y float64, err error) {
+func (w *Window) GetCursorPos() (x, y float64) {
 	var xpos, ypos C.double
 	C.glfwGetCursorPos(w.data, &xpos, &ypos)
-	return float64(xpos), float64(ypos), fetchError()
+	panicError()
+	return float64(xpos), float64(ypos)
 }
 
 // SetCursorPos sets the position of the cursor. The specified window must
@@ -357,9 +364,9 @@ func (w *Window) GetCursorPos() (x, y float64, err error) {
 //
 // If the cursor is disabled (with CursorDisabled) then the cursor position is
 // unbounded and limited only by the minimum and maximum values of a double.
-func (w *Window) SetCursorPos(xpos, ypos float64) error {
+func (w *Window) SetCursorPos(xpos, ypos float64) {
 	C.glfwSetCursorPos(w.data, C.double(xpos), C.double(ypos))
-	return fetchError()
+	panicError()
 }
 
 // Creates a new custom cursor image that can be set for a window with SetCursor.
@@ -367,44 +374,45 @@ func (w *Window) SetCursorPos(xpos, ypos float64) error {
 //
 // The pixels are 32-bit little-endian RGBA, i.e. eight bits per channel. They are arranged
 // canonically as packed sequential rows, starting from the top-left corner.
-// 
+//
 // All non-RGBA images will be converted to RGBA.
 //
 // The cursor hotspot is specified in pixels, relative to the upper-left corner of the cursor image.
 // Like all other coordinate systems in GLFW, the X-axis points to the right and the Y-axis points down.
-func CreateCursor(img image.Image, xhot, yhot int) (*Cursor, error) {
+func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
 	var img_c C.GLFWimage
 	var pixPointer *uint8
 	b := img.Bounds()
 
 	switch img := img.(type) {
-		case *image.RGBA:
-			pixPointer = &img.Pix[0]
-		default:
-			m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
-			draw.Draw(m, m.Bounds(), img, b.Min, draw.Src)
-			pixPointer = &m.Pix[0]
+	case *image.RGBA:
+		pixPointer = &img.Pix[0]
+	default:
+		m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+		draw.Draw(m, m.Bounds(), img, b.Min, draw.Src)
+		pixPointer = &m.Pix[0]
 	}
-	
+
 	img_c.width = C.int(b.Dx())
 	img_c.height = C.int(b.Dy())
 	img_c.pixels = (*C.uchar)(pixPointer)
 	c := C.glfwCreateCursor(&img_c, C.int(xhot), C.int(yhot))
-	
-	return &Cursor{c}, fetchError()
+	panicError()
+	return &Cursor{c}
 }
 
 // Returns a cursor with a standard shape, that can be set for a window with SetCursor.
-func CreateStandardCursor(shape int) (*Cursor, error) {
+func CreateStandardCursor(shape int) *Cursor {
 	c := C.glfwCreateStandardCursor(C.int(shape))
-	return &Cursor{c}, fetchError()
+	panicError()
+	return &Cursor{c}
 }
 
 // This function destroys a cursor previously created with CreateCursor.
 // Any remaining cursors will be destroyed by Terminate.
-func (c *Cursor) Destroy() error {
+func (c *Cursor) Destroy() {
 	C.glfwDestroyCursor(c.data)
-	return fetchError()
+	panicError()
 }
 
 // This function sets the cursor image to be used when the cursor is over the client area
@@ -412,14 +420,13 @@ func (c *Cursor) Destroy() error {
 // window is CursorNormal.
 //
 // On some platforms, the set cursor may not be visible unless the window also has input focus.
-func (w *Window) SetCursor(c *Cursor) error {
+func (w *Window) SetCursor(c *Cursor) {
 	if c == nil {
 		C.glfwSetCursor(w.data, nil)
 	} else {
 		C.glfwSetCursor(w.data, c.data)
 	}
-
-	return fetchError()
+	panicError()
 }
 
 type KeyCallback func(w *Window, key Key, scancode int, action Action, mods ModifierKey)
@@ -436,7 +443,7 @@ type KeyCallback func(w *Window, key Key, scancode int, action Action, mods Modi
 // fact that the synthetic ones are generated after the window has lost focus,
 // i.e. Focused will be false and the focus callback will have already been
 // called.
-func (w *Window) SetKeyCallback(cbfun KeyCallback) (previous KeyCallback, err error) {
+func (w *Window) SetKeyCallback(cbfun KeyCallback) (previous KeyCallback) {
 	previous = w.fKeyHolder
 	w.fKeyHolder = cbfun
 	if cbfun == nil {
@@ -444,7 +451,8 @@ func (w *Window) SetKeyCallback(cbfun KeyCallback) (previous KeyCallback, err er
 	} else {
 		C.glfwSetKeyCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type CharCallback func(w *Window, char rune)
@@ -463,7 +471,7 @@ type CharCallback func(w *Window, char rune)
 // not be called if modifier keys are held down that would prevent normal text
 // input on that platform, for example a Super (Command) key on OS X or Alt key
 // on Windows. There is a character with modifiers callback that receives these events.
-func (w *Window) SetCharCallback(cbfun CharCallback) (previous CharCallback, err error) {
+func (w *Window) SetCharCallback(cbfun CharCallback) (previous CharCallback) {
 	previous = w.fCharHolder
 	w.fCharHolder = cbfun
 	if cbfun == nil {
@@ -471,7 +479,8 @@ func (w *Window) SetCharCallback(cbfun CharCallback) (previous CharCallback, err
 	} else {
 		C.glfwSetCharCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type CharModsCallback func(w *Window, char rune, mods ModifierKey)
@@ -486,7 +495,7 @@ type CharModsCallback func(w *Window, char rune, mods ModifierKey)
 // map 1:1 to physical keys, as a key may produce zero, one or more characters.
 // If you want to know whether a specific physical key was pressed or released,
 // see the key callback instead.
-func (w *Window) SetCharModsCallback(cbfun CharModsCallback) (previous CharModsCallback, err error) {
+func (w *Window) SetCharModsCallback(cbfun CharModsCallback) (previous CharModsCallback) {
 	previous = w.fCharModsHolder
 	w.fCharModsHolder = cbfun
 	if cbfun == nil {
@@ -494,7 +503,8 @@ func (w *Window) SetCharModsCallback(cbfun CharModsCallback) (previous CharModsC
 	} else {
 		C.glfwSetCharModsCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type MouseButtonCallback func(w *Window, button MouseButton, action Action, mod ModifierKey)
@@ -507,7 +517,7 @@ type MouseButtonCallback func(w *Window, button MouseButton, action Action, mod 
 // user-generated events by the fact that the synthetic ones are generated after
 // the window has lost focus, i.e. Focused will be false and the focus
 // callback will have already been called.
-func (w *Window) SetMouseButtonCallback(cbfun MouseButtonCallback) (previous MouseButtonCallback, err error) {
+func (w *Window) SetMouseButtonCallback(cbfun MouseButtonCallback) (previous MouseButtonCallback) {
 	previous = w.fMouseButtonHolder
 	w.fMouseButtonHolder = cbfun
 	if cbfun == nil {
@@ -515,7 +525,8 @@ func (w *Window) SetMouseButtonCallback(cbfun MouseButtonCallback) (previous Mou
 	} else {
 		C.glfwSetMouseButtonCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type CursorPosCallback func(w *Window, xpos float64, ypos float64)
@@ -523,7 +534,7 @@ type CursorPosCallback func(w *Window, xpos float64, ypos float64)
 // SetCursorPosCallback sets the cursor position callback which is called
 // when the cursor is moved. The callback is provided with the position relative
 // to the upper-left corner of the client area of the window.
-func (w *Window) SetCursorPosCallback(cbfun CursorPosCallback) (previous CursorPosCallback, err error) {
+func (w *Window) SetCursorPosCallback(cbfun CursorPosCallback) (previous CursorPosCallback) {
 	previous = w.fCursorPosHolder
 	w.fCursorPosHolder = cbfun
 	if cbfun == nil {
@@ -531,14 +542,15 @@ func (w *Window) SetCursorPosCallback(cbfun CursorPosCallback) (previous CursorP
 	} else {
 		C.glfwSetCursorPosCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type CursorEnterCallback func(w *Window, entered bool)
 
 // SetCursorEnterCallback the cursor boundary crossing callback which is called
 // when the cursor enters or leaves the client area of the window.
-func (w *Window) SetCursorEnterCallback(cbfun CursorEnterCallback) (previous CursorEnterCallback, err error) {
+func (w *Window) SetCursorEnterCallback(cbfun CursorEnterCallback) (previous CursorEnterCallback) {
 	previous = w.fCursorEnterHolder
 	w.fCursorEnterHolder = cbfun
 	if cbfun == nil {
@@ -546,14 +558,14 @@ func (w *Window) SetCursorEnterCallback(cbfun CursorEnterCallback) (previous Cur
 	} else {
 		C.glfwSetCursorEnterCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	return previous
 }
 
 type ScrollCallback func(w *Window, xoff float64, yoff float64)
 
 // SetScrollCallback sets the scroll callback which is called when a scrolling
 // device is used, such as a mouse wheel or scrolling area of a touchpad.
-func (w *Window) SetScrollCallback(cbfun ScrollCallback) (previous ScrollCallback, err error) {
+func (w *Window) SetScrollCallback(cbfun ScrollCallback) (previous ScrollCallback) {
 	previous = w.fScrollHolder
 	w.fScrollHolder = cbfun
 	if cbfun == nil {
@@ -561,14 +573,15 @@ func (w *Window) SetScrollCallback(cbfun ScrollCallback) (previous ScrollCallbac
 	} else {
 		C.glfwSetScrollCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type DropCallback func(w *Window, names []string)
 
 // SetDropCallback sets the drop callback which is called when an object
 // is dropped over the window.
-func (w *Window) SetDropCallback(cbfun DropCallback) (previous DropCallback, err error) {
+func (w *Window) SetDropCallback(cbfun DropCallback) (previous DropCallback) {
 	previous = w.fDropHolder
 	w.fDropHolder = cbfun
 	if cbfun == nil {
@@ -576,50 +589,54 @@ func (w *Window) SetDropCallback(cbfun DropCallback) (previous DropCallback, err
 	} else {
 		C.glfwSetDropCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 // GetJoystickPresent returns whether the specified joystick is present.
-func JoystickPresent(joy Joystick) (bool, error) {
-	return glfwbool(C.glfwJoystickPresent(C.int(joy))), fetchError()
+func JoystickPresent(joy Joystick) bool {
+	ret := glfwbool(C.glfwJoystickPresent(C.int(joy)))
+	panicError()
+	return ret
 }
 
 // GetJoystickAxes returns a slice of axis values.
-func GetJoystickAxes(joy Joystick) ([]float32, error) {
+func GetJoystickAxes(joy Joystick) []float32 {
 	var length int
 
 	axis := C.glfwGetJoystickAxes(C.int(joy), (*C.int)(unsafe.Pointer(&length)))
+	panicError()
 	if axis == nil {
-		return nil, fetchError()
+		return nil
 	}
 
 	a := make([]float32, length)
 	for i := 0; i < length; i++ {
 		a[i] = float32(C.GetAxisAtIndex(axis, C.int(i)))
 	}
-
-	return a, fetchError()
+	return a
 }
 
 // GetJoystickButtons returns a slice of button values.
-func GetJoystickButtons(joy Joystick) ([]byte, error) {
+func GetJoystickButtons(joy Joystick) []byte {
 	var length int
 
 	buttons := C.glfwGetJoystickButtons(C.int(joy), (*C.int)(unsafe.Pointer(&length)))
+	panicError()
 	if buttons == nil {
-		return nil, fetchError()
+		return nil
 	}
 
 	b := make([]byte, length)
 	for i := 0; i < length; i++ {
 		b[i] = byte(C.GetButtonsAtIndex(buttons, C.int(i)))
 	}
-
-	return b, fetchError()
+	return b
 }
 
 // GetJoystickName returns the name, encoded as UTF-8, of the specified joystick.
-func GetJoystickName(joy Joystick) (string, error) {
+func GetJoystickName(joy Joystick) string {
 	jn := C.glfwGetJoystickName(C.int(joy))
-	return C.GoString(jn), fetchError()
+	panicError()
+	return C.GoString(jn)
 }

--- a/input.go
+++ b/input.go
@@ -558,6 +558,7 @@ func (w *Window) SetCursorEnterCallback(cbfun CursorEnterCallback) (previous Cur
 	} else {
 		C.glfwSetCursorEnterCallbackCB(w.data)
 	}
+	panicError()
 	return previous
 }
 

--- a/monitor.go
+++ b/monitor.go
@@ -50,12 +50,13 @@ func goMonitorCB(monitor unsafe.Pointer, event C.int) {
 }
 
 // GetMonitors returns a slice of handles for all currently connected monitors.
-func GetMonitors() ([]*Monitor, error) {
+func GetMonitors() []*Monitor {
 	var length int
 
 	mC := C.glfwGetMonitors((*C.int)(unsafe.Pointer(&length)))
+	panicError()
 	if mC == nil {
-		return nil, fetchError()
+		return nil
 	}
 
 	m := make([]*Monitor, length)
@@ -64,25 +65,27 @@ func GetMonitors() ([]*Monitor, error) {
 		m[i] = &Monitor{C.GetMonitorAtIndex(mC, C.int(i))}
 	}
 
-	return m, nil
+	return m
 }
 
 // GetPrimaryMonitor returns the primary monitor. This is usually the monitor
 // where elements like the Windows task bar or the OS X menu bar is located.
-func GetPrimaryMonitor() (*Monitor, error) {
+func GetPrimaryMonitor() *Monitor {
 	m := C.glfwGetPrimaryMonitor()
+	panicError()
 	if m == nil {
-		return nil, fetchError()
+		return nil
 	}
-	return &Monitor{m}, nil
+	return &Monitor{m}
 }
 
 // GetPos returns the position, in screen coordinates, of the upper-left
 // corner of the monitor.
-func (m *Monitor) GetPos() (x, y int, err error) {
+func (m *Monitor) GetPos() (x, y int) {
 	var xpos, ypos C.int
 	C.glfwGetMonitorPos(m.data, &xpos, &ypos)
-	return int(xpos), int(ypos), fetchError()
+	panicError()
+	return int(xpos), int(ypos)
 }
 
 // GetPhysicalSize returns the size, in millimetres, of the display area of the
@@ -91,44 +94,48 @@ func (m *Monitor) GetPos() (x, y int, err error) {
 // Note: Some operating systems do not provide accurate information, either
 // because the monitor's EDID data is incorrect, or because the driver does not
 // report it accurately.
-func (m *Monitor) GetPhysicalSize() (width, height int, err error) {
+func (m *Monitor) GetPhysicalSize() (width, height int) {
 	var wi, h C.int
 	C.glfwGetMonitorPhysicalSize(m.data, &wi, &h)
-	return int(wi), int(h), fetchError()
+	panicError()
+	return int(wi), int(h)
 }
 
 // GetName returns a human-readable name of the monitor, encoded as UTF-8.
-func (m *Monitor) GetName() (string, error) {
+func (m *Monitor) GetName() string {
 	mn := C.glfwGetMonitorName(m.data)
+	panicError()
 	if mn == nil {
-		return "", fetchError()
+		return ""
 	}
-	return C.GoString(mn), nil
+	return C.GoString(mn)
 }
 
 // SetMonitorCallback sets the monitor configuration callback, or removes the
 // currently set callback. This is called when a monitor is connected to or
 // disconnected from the system.
-func SetMonitorCallback(cbfun func(monitor *Monitor, event MonitorEvent)) error {
+func SetMonitorCallback(cbfun func(monitor *Monitor, event MonitorEvent)) {
 	if cbfun == nil {
 		C.glfwSetMonitorCallback(nil)
 	} else {
 		fMonitorHolder = cbfun
 		C.glfwSetMonitorCallbackCB()
 	}
-	return fetchError()
+	panicError()
+	return
 }
 
 // GetVideoModes returns an array of all video modes supported by the monitor.
 // The returned array is sorted in ascending order, first by color bit depth
 // (the sum of all channel depths) and then by resolution area (the product of
 // width and height).
-func (m *Monitor) GetVideoModes() ([]*VidMode, error) {
+func (m *Monitor) GetVideoModes() []*VidMode {
 	var length int
 
 	vC := C.glfwGetVideoModes(m.data, (*C.int)(unsafe.Pointer(&length)))
+	panicError()
 	if vC == nil {
-		return nil, fetchError()
+		return nil
 	}
 
 	v := make([]*VidMode, length)
@@ -138,34 +145,37 @@ func (m *Monitor) GetVideoModes() ([]*VidMode, error) {
 		v[i] = &VidMode{int(t.width), int(t.height), int(t.redBits), int(t.greenBits), int(t.blueBits), int(t.refreshRate)}
 	}
 
-	return v, nil
+	return v
 }
 
 // GetVideoMode returns the current video mode of the monitor. If you
 // are using a full screen window, the return value will therefore depend on
 // whether it is focused.
-func (m *Monitor) GetVideoMode() (*VidMode, error) {
+func (m *Monitor) GetVideoMode() *VidMode {
 	t := C.glfwGetVideoMode(m.data)
 	if t == nil {
-		return nil, fetchError()
+		return nil
 	}
-	return &VidMode{int(t.width), int(t.height), int(t.redBits), int(t.greenBits), int(t.blueBits), int(t.refreshRate)}, nil
+	panicError()
+	return &VidMode{int(t.width), int(t.height), int(t.redBits), int(t.greenBits), int(t.blueBits), int(t.refreshRate)}
 }
 
 // SetGamma generates a 256-element gamma ramp from the specified exponent and then calls
 // SetGamma with it.
-func (m *Monitor) SetGamma(gamma float32) error {
+func (m *Monitor) SetGamma(gamma float32) {
 	C.glfwSetGamma(m.data, C.float(gamma))
-	return fetchError()
+	panicError()
+	return
 }
 
 // GetGammaRamp retrieves the current gamma ramp of the monitor.
-func (m *Monitor) GetGammaRamp() (*GammaRamp, error) {
+func (m *Monitor) GetGammaRamp() *GammaRamp {
 	var ramp GammaRamp
 
 	rampC := C.glfwGetGammaRamp(m.data)
+	panicError()
 	if rampC == nil {
-		return nil, fetchError()
+		return nil
 	}
 
 	length := int(rampC.size)
@@ -179,11 +189,11 @@ func (m *Monitor) GetGammaRamp() (*GammaRamp, error) {
 		ramp.Blue[i] = uint16(C.GetGammaAtIndex(rampC.blue, C.int(i)))
 	}
 
-	return &ramp, nil
+	return &ramp
 }
 
 // SetGammaRamp sets the current gamma ramp for the monitor.
-func (m *Monitor) SetGammaRamp(ramp *GammaRamp) error {
+func (m *Monitor) SetGammaRamp(ramp *GammaRamp) {
 	var rampC C.GLFWgammaramp
 
 	length := len(ramp.Red)
@@ -195,5 +205,6 @@ func (m *Monitor) SetGammaRamp(ramp *GammaRamp) error {
 	}
 
 	C.glfwSetGammaRamp(m.data, &rampC)
-	return fetchError()
+	panicError()
+	return
 }

--- a/monitor.go
+++ b/monitor.go
@@ -122,7 +122,6 @@ func SetMonitorCallback(cbfun func(monitor *Monitor, event MonitorEvent)) {
 		C.glfwSetMonitorCallbackCB()
 	}
 	panicError()
-	return
 }
 
 // GetVideoModes returns an array of all video modes supported by the monitor.
@@ -165,7 +164,6 @@ func (m *Monitor) GetVideoMode() *VidMode {
 func (m *Monitor) SetGamma(gamma float32) {
 	C.glfwSetGamma(m.data, C.float(gamma))
 	panicError()
-	return
 }
 
 // GetGammaRamp retrieves the current gamma ramp of the monitor.
@@ -206,5 +204,4 @@ func (m *Monitor) SetGammaRamp(ramp *GammaRamp) {
 
 	C.glfwSetGammaRamp(m.data, &rampC)
 	panicError()
-	return
 }

--- a/native_darwin.go
+++ b/native_darwin.go
@@ -8,11 +8,15 @@ import "C"
 
 // See: https://github.com/go-gl/glfw3/issues/82
 /*
-func (w *Window) GetCocoaWindow() (C.id, error) {
-	return C.glfwGetCocoaWindow(w.data), fetchError()
+func (w *Window) GetCocoaWindow() C.id {
+	ret := C.glfwGetCocoaWindow(w.data)
+	panicError()
+	return ret
 }
 
-func (w *Window) GetNSGLContext() (C.id, error) {
-	return C.glfwGetNSGLContext(w.data), fetchError()
+func (w *Window) GetNSGLContext() C.id {
+	ret := C.glfwGetNSGLContext(w.data)
+	panicError()
+	return ret
 }
 */

--- a/native_linbsd.go
+++ b/native_linbsd.go
@@ -8,14 +8,20 @@ package glfw3
 //#include "glfw/include/GLFW/glfw3native.h"
 import "C"
 
-func (w *Window) GetX11Window() (C.Window, error) {
-	return C.glfwGetX11Window(w.data), fetchError()
+func (w *Window) GetX11Window() C.Window {
+	ret := C.glfwGetX11Window(w.data)
+	panicError()
+	return ret
 }
 
-func (w *Window) GetGLXContext() (C.GLXContext, error) {
-	return C.glfwGetGLXContext(w.data), fetchError()
+func (w *Window) GetGLXContext() C.GLXContext {
+	ret := C.glfwGetGLXContext(w.data)
+	panicError()
+	return ret
 }
 
-func GetX11Display() (*C.Display, error) {
-	return C.glfwGetX11Display(), fetchError()
+func GetX11Display() *C.Display {
+	ret := C.glfwGetX11Display()
+	panicError()
+	return ret
 }

--- a/native_windows.go
+++ b/native_windows.go
@@ -6,10 +6,14 @@ package glfw3
 //#include "glfw/include/GLFW/glfw3native.h"
 import "C"
 
-func (w *Window) GetWin32Window() (C.HWND, error) {
-	return C.glfwGetWin32Window(w.data), fetchError()
+func (w *Window) GetWin32Window() C.HWND {
+	ret := C.glfwGetWin32Window(w.data)
+	panicError()
+	return ret
 }
 
-func (w *Window) GetWGLContext() (C.HGLRC, error) {
-	return C.glfwGetWGLContext(w.data), fetchError()
+func (w *Window) GetWGLContext() C.HGLRC {
+	ret := C.glfwGetWGLContext(w.data)
+	panicError()
+	return ret
 }

--- a/time.go
+++ b/time.go
@@ -9,8 +9,10 @@ import "C"
 // The resolution of the timer is system dependent, but is usually on the order
 // of a few micro- or nanoseconds. It uses the highest-resolution monotonic time
 // source on each supported platform.
-func GetTime() (float64, error) {
-	return float64(C.glfwGetTime()), fetchError()
+func GetTime() float64 {
+	ret := float64(C.glfwGetTime())
+	panicError()
+	return ret
 }
 
 // SetTime sets the value of the GLFW timer. It then continues to count up from
@@ -19,7 +21,7 @@ func GetTime() (float64, error) {
 // The resolution of the timer is system dependent, but is usually on the order
 // of a few micro- or nanoseconds. It uses the highest-resolution monotonic time
 // source on each supported platform.
-func SetTime(time float64) error {
+func SetTime(time float64) {
 	C.glfwSetTime(C.double(time))
-	return fetchError()
+	panicError()
 }

--- a/window.go
+++ b/window.go
@@ -196,9 +196,9 @@ func goWindowIconifyCB(window unsafe.Pointer, iconified C.int) {
 // DefaultHints resets all window hints to their default values.
 //
 // This function may only be called from the main thread.
-func DefaultWindowHints() error {
+func DefaultWindowHints() {
 	C.glfwDefaultWindowHints()
-	return fetchError()
+	panicError()
 }
 
 // Hint function sets hints for the next call to CreateWindow. The hints,
@@ -206,9 +206,9 @@ func DefaultWindowHints() error {
 // DefaultHints, or until the library is terminated with Terminate.
 //
 // This function may only be called from the main thread.
-func WindowHint(target Hint, hint int) error {
+func WindowHint(target Hint, hint int) {
 	C.glfwWindowHint(C.int(target), C.int(hint))
-	return fetchError()
+	panicError()
 }
 
 // CreateWindow creates a window and its associated context. Most of the options
@@ -261,7 +261,7 @@ func CreateWindow(width, height int, title string, monitor *Monitor, share *Wind
 
 	w := C.glfwCreateWindow(C.int(width), C.int(height), t, m, s)
 	if w == nil {
-		return nil, fetchError()
+		return nil, acceptError(APIUnavailable, VersionUnavailable)
 	}
 
 	wnd := &Window{data: w}
@@ -273,45 +273,48 @@ func CreateWindow(width, height int, title string, monitor *Monitor, share *Wind
 // function, no further callbacks will be called for that window.
 //
 // This function may only be called from the main thread.
-func (w *Window) Destroy() error {
+func (w *Window) Destroy() {
 	windows.remove(w.data)
 	C.glfwDestroyWindow(w.data)
-	return fetchError()
+	panicError()
 }
 
 // ShouldClose returns the value of the close flag of the specified window.
-func (w *Window) ShouldClose() (bool, error) {
-	return glfwbool(C.glfwWindowShouldClose(w.data)), fetchError()
+func (w *Window) ShouldClose() bool {
+	ret := glfwbool(C.glfwWindowShouldClose(w.data))
+	panicError()
+	return ret
 }
 
 // SetShouldClose sets the value of the close flag of the window. This can be
 // used to override the user's attempt to close the window, or to signal that it
 // should be closed.
-func (w *Window) SetShouldClose(value bool) error {
+func (w *Window) SetShouldClose(value bool) {
 	if !value {
 		C.glfwSetWindowShouldClose(w.data, C.GL_FALSE)
 	} else {
 		C.glfwSetWindowShouldClose(w.data, C.GL_TRUE)
 	}
-	return fetchError()
+	panicError()
 }
 
 // SetTitle sets the window title, encoded as UTF-8, of the window.
 //
 // This function may only be called from the main thread.
-func (w *Window) SetTitle(title string) error {
+func (w *Window) SetTitle(title string) {
 	t := C.CString(title)
 	defer C.free(unsafe.Pointer(t))
 	C.glfwSetWindowTitle(w.data, t)
-	return fetchError()
+	panicError()
 }
 
 // GetPos returns the position, in screen coordinates, of the upper-left
 // corner of the client area of the window.
-func (w *Window) GetPos() (x, y int, err error) {
+func (w *Window) GetPos() (x, y int) {
 	var xpos, ypos C.int
 	C.glfwGetWindowPos(w.data, &xpos, &ypos)
-	return int(xpos), int(ypos), fetchError()
+	panicError()
+	return int(xpos), int(ypos)
 }
 
 // SetPos sets the position, in screen coordinates, of the upper-left corner
@@ -328,17 +331,18 @@ func (w *Window) GetPos() (x, y int, err error) {
 // The window manager may put limits on what positions are allowed.
 //
 // This function may only be called from the main thread.
-func (w *Window) SetPos(xpos, ypos int) error {
+func (w *Window) SetPos(xpos, ypos int) {
 	C.glfwSetWindowPos(w.data, C.int(xpos), C.int(ypos))
-	return fetchError()
+	panicError()
 }
 
 // GetSize returns the size, in screen coordinates, of the client area of the
 // specified window.
-func (w *Window) GetSize() (width, height int, err error) {
+func (w *Window) GetSize() (width, height int) {
 	var wi, h C.int
 	C.glfwGetWindowSize(w.data, &wi, &h)
-	return int(wi), int(h), fetchError()
+	panicError()
+	return int(wi), int(h)
 }
 
 // SetSize sets the size, in screen coordinates, of the client area of the
@@ -351,17 +355,18 @@ func (w *Window) GetSize() (width, height int, err error) {
 // The window manager may put limits on what window sizes are allowed.
 //
 // This function may only be called from the main thread.
-func (w *Window) SetSize(width, height int) error {
+func (w *Window) SetSize(width, height int) {
 	C.glfwSetWindowSize(w.data, C.int(width), C.int(height))
-	return fetchError()
+	panicError()
 }
 
 // GetFramebufferSize retrieves the size, in pixels, of the framebuffer of the
 // specified window.
-func (w *Window) GetFramebufferSize() (width, height int, err error) {
+func (w *Window) GetFramebufferSize() (width, height int) {
 	var wi, h C.int
 	C.glfwGetFramebufferSize(w.data, &wi, &h)
-	return int(wi), int(h), fetchError()
+	panicError()
+	return int(wi), int(h)
 }
 
 // GetFrameSize retrieves the size, in screen coordinates, of each edge of the frame
@@ -370,10 +375,11 @@ func (w *Window) GetFramebufferSize() (width, height int, err error) {
 //
 // Because this function retrieves the size of each window frame edge and not the offset
 // along a particular coordinate axis, the retrieved values will always be zero or positive.
-func (w *Window) GetFrameSize() (left, top, right, bottom int, err error) {
+func (w *Window) GetFrameSize() (left, top, right, bottom int) {
 	var l, t, r, b C.int
 	C.glfwGetWindowFrameSize(w.data, &l, &t, &r, &b)
-	return int(l), int(t), int(r), int(b), fetchError()
+	panicError()
+	return int(l), int(t), int(r), int(b)
 }
 
 // Iconfiy iconifies/minimizes the window, if it was previously restored. If it
@@ -384,7 +390,7 @@ func (w *Window) GetFrameSize() (left, top, right, bottom int, err error) {
 // This function may only be called from the main thread.
 func (w *Window) Iconify() error {
 	C.glfwIconifyWindow(w.data)
-	return fetchError()
+	return acceptError(APIUnavailable)
 }
 
 // Restore restores the window, if it was previously iconified/minimized. If it
@@ -395,54 +401,61 @@ func (w *Window) Iconify() error {
 // This function may only be called from the main thread.
 func (w *Window) Restore() error {
 	C.glfwRestoreWindow(w.data)
-	return fetchError()
+	return acceptError(APIUnavailable)
 }
 
 // Show makes the window visible, if it was previously hidden. If the window is
 // already visible or is in full screen mode, this function does nothing.
 //
 // This function may only be called from the main thread.
-func (w *Window) Show() error {
+func (w *Window) Show() {
 	C.glfwShowWindow(w.data)
-	return fetchError()
+	panicError()
 }
 
 // Hide hides the window, if it was previously visible. If the window is already
 // hidden or is in full screen mode, this function does nothing.
 //
 // This function may only be called from the main thread.
-func (w *Window) Hide() error {
+func (w *Window) Hide() {
 	C.glfwHideWindow(w.data)
-	return fetchError()
+	panicError()
 }
 
 // GetMonitor returns the handle of the monitor that the window is in
 // fullscreen on.
-func (w *Window) GetMonitor() (*Monitor, error) {
+//
+// Returns nil if the window is in windowed mode.
+func (w *Window) GetMonitor() *Monitor {
 	m := C.glfwGetWindowMonitor(w.data)
+	panicError()
 	if m == nil {
-		return nil, fetchError()
+		return nil
 	}
-	return &Monitor{m}, nil
+	return &Monitor{m}
 }
 
 // GetAttrib returns an attribute of the window. There are many attributes,
 // some related to the window and others to its context.
-func (w *Window) GetAttrib(attrib Hint) (int, error) {
-	return int(C.glfwGetWindowAttrib(w.data, C.int(attrib))), fetchError()
+func (w *Window) GetAttrib(attrib Hint) int {
+	ret := int(C.glfwGetWindowAttrib(w.data, C.int(attrib)))
+	panicError()
+	return ret
 }
 
 // SetUserPointer sets the user-defined pointer of the window. The current value
 // is retained until the window is destroyed. The initial value is nil.
-func (w *Window) SetUserPointer(pointer unsafe.Pointer) error {
+func (w *Window) SetUserPointer(pointer unsafe.Pointer) {
 	C.glfwSetWindowUserPointer(w.data, pointer)
-	return fetchError()
+	panicError()
 }
 
 // GetUserPointer returns the current value of the user-defined pointer of the
 // window. The initial value is nil.
-func (w *Window) GetUserPointer() (unsafe.Pointer, error) {
-	return C.glfwGetWindowUserPointer(w.data), fetchError()
+func (w *Window) GetUserPointer() unsafe.Pointer {
+	ret := C.glfwGetWindowUserPointer(w.data)
+	panicError()
+	return ret
 }
 
 type PosCallback func(w *Window, xpos int, ypos int)
@@ -450,7 +463,7 @@ type PosCallback func(w *Window, xpos int, ypos int)
 // SetPosCallback sets the position callback of the window, which is called
 // when the window is moved. The callback is provided with the screen position
 // of the upper-left corner of the client area of the window.
-func (w *Window) SetPosCallback(cbfun PosCallback) (previous PosCallback, err error) {
+func (w *Window) SetPosCallback(cbfun PosCallback) (previous PosCallback) {
 	previous = w.fPosHolder
 	w.fPosHolder = cbfun
 	if cbfun == nil {
@@ -458,7 +471,8 @@ func (w *Window) SetPosCallback(cbfun PosCallback) (previous PosCallback, err er
 	} else {
 		C.glfwSetWindowPosCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type SizeCallback func(w *Window, width int, height int)
@@ -466,7 +480,7 @@ type SizeCallback func(w *Window, width int, height int)
 // SetSizeCallback sets the size callback of the window, which is called when
 // the window is resized. The callback is provided with the size, in screen
 // coordinates, of the client area of the window.
-func (w *Window) SetSizeCallback(cbfun SizeCallback) (previous SizeCallback, err error) {
+func (w *Window) SetSizeCallback(cbfun SizeCallback) (previous SizeCallback) {
 	previous = w.fSizeHolder
 	w.fSizeHolder = cbfun
 	if cbfun == nil {
@@ -474,14 +488,15 @@ func (w *Window) SetSizeCallback(cbfun SizeCallback) (previous SizeCallback, err
 	} else {
 		C.glfwSetWindowSizeCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type FramebufferSizeCallback func(w *Window, width int, height int)
 
 // SetFramebufferSizeCallback sets the framebuffer resize callback of the specified
 // window, which is called when the framebuffer of the specified window is resized.
-func (w *Window) SetFramebufferSizeCallback(cbfun FramebufferSizeCallback) (previous FramebufferSizeCallback, err error) {
+func (w *Window) SetFramebufferSizeCallback(cbfun FramebufferSizeCallback) (previous FramebufferSizeCallback) {
 	previous = w.fFramebufferSizeHolder
 	w.fFramebufferSizeHolder = cbfun
 	if cbfun == nil {
@@ -489,7 +504,8 @@ func (w *Window) SetFramebufferSizeCallback(cbfun FramebufferSizeCallback) (prev
 	} else {
 		C.glfwSetFramebufferSizeCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type CloseCallback func(w *Window)
@@ -503,7 +519,7 @@ type CloseCallback func(w *Window)
 //
 // Mac OS X: Selecting Quit from the application menu will trigger the close
 // callback for all windows.
-func (w *Window) SetCloseCallback(cbfun CloseCallback) (previous CloseCallback, err error) {
+func (w *Window) SetCloseCallback(cbfun CloseCallback) (previous CloseCallback) {
 	previous = w.fCloseHolder
 	w.fCloseHolder = cbfun
 	if cbfun == nil {
@@ -511,7 +527,8 @@ func (w *Window) SetCloseCallback(cbfun CloseCallback) (previous CloseCallback, 
 	} else {
 		C.glfwSetWindowCloseCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type RefreshCallback func(w *Window)
@@ -523,7 +540,7 @@ type RefreshCallback func(w *Window)
 // On compositing window systems such as Aero, Compiz or Aqua, where the window
 // contents are saved off-screen, this callback may be called only very
 // infrequently or never at all.
-func (w *Window) SetRefreshCallback(cbfun RefreshCallback) (previous RefreshCallback, err error) {
+func (w *Window) SetRefreshCallback(cbfun RefreshCallback) (previous RefreshCallback) {
 	previous = w.fRefreshHolder
 	w.fRefreshHolder = cbfun
 	if cbfun == nil {
@@ -531,7 +548,8 @@ func (w *Window) SetRefreshCallback(cbfun RefreshCallback) (previous RefreshCall
 	} else {
 		C.glfwSetWindowRefreshCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type FocusCallback func(w *Window, focused bool)
@@ -542,7 +560,7 @@ type FocusCallback func(w *Window, focused bool)
 // After the focus callback is called for a window that lost focus, synthetic key
 // and mouse button release events will be generated for all such that had been
 // pressed. For more information, see SetKeyCallback and SetMouseButtonCallback.
-func (w *Window) SetFocusCallback(cbfun FocusCallback) (previous FocusCallback, err error) {
+func (w *Window) SetFocusCallback(cbfun FocusCallback) (previous FocusCallback) {
 	previous = w.fFocusHolder
 	w.fFocusHolder = cbfun
 	if cbfun == nil {
@@ -550,14 +568,15 @@ func (w *Window) SetFocusCallback(cbfun FocusCallback) (previous FocusCallback, 
 	} else {
 		C.glfwSetWindowFocusCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 type IconifyCallback func(w *Window, iconified bool)
 
 // SetIconifyCallback sets the iconification callback of the window, which is
 // called when the window is iconified or restored.
-func (w *Window) SetIconifyCallback(cbfun IconifyCallback) (previous IconifyCallback, err error) {
+func (w *Window) SetIconifyCallback(cbfun IconifyCallback) (previous IconifyCallback) {
 	previous = w.fIconifyHolder
 	w.fIconifyHolder = cbfun
 	if cbfun == nil {
@@ -565,18 +584,20 @@ func (w *Window) SetIconifyCallback(cbfun IconifyCallback) (previous IconifyCall
 	} else {
 		C.glfwSetWindowIconifyCallbackCB(w.data)
 	}
-	return previous, fetchError()
+	panicError()
+	return previous
 }
 
 // SetClipboardString sets the system clipboard to the specified UTF-8 encoded
 // string.
 //
 // This function may only be called from the main thread.
-func (w *Window) SetClipboardString(str string) error {
+func (w *Window) SetClipboardString(str string) {
 	cp := C.CString(str)
 	defer C.free(unsafe.Pointer(cp))
 	C.glfwSetClipboardString(w.data, cp)
-	return fetchError()
+	panicError()
+	return
 }
 
 // GetClipboardString returns the contents of the system clipboard, if it
@@ -586,7 +607,7 @@ func (w *Window) SetClipboardString(str string) error {
 func (w *Window) GetClipboardString() (string, error) {
 	cs := C.glfwGetClipboardString(w.data)
 	if cs == nil {
-		return "", fetchError()
+		return "", acceptError(FormatUnavailable)
 	}
 	return C.GoString(cs), nil
 }
@@ -600,9 +621,9 @@ func (w *Window) GetClipboardString() (string, error) {
 // This function may not be called from a callback.
 //
 // This function may only be called from the main thread.
-func PollEvents() error {
+func PollEvents() {
 	C.glfwPollEvents()
-	return fetchError()
+	panicError()
 }
 
 // WaitEvents puts the calling thread to sleep until at least one event has been
@@ -618,9 +639,9 @@ func PollEvents() error {
 // This function may not be called from a callback.
 //
 // This function may only be called from the main thread.
-func WaitEvents() error {
+func WaitEvents() {
 	C.glfwWaitEvents()
-	return fetchError()
+	panicError()
 }
 
 // PostEmptyEvent posts an empty event from the current thread to the main
@@ -631,7 +652,7 @@ func WaitEvents() error {
 // your threading library of choice.
 //
 // This function may be called from secondary threads.
-func PostEmptyEvent() error {
+func PostEmptyEvent() {
 	C.glfwPostEmptyEvent()
-	return fetchError()
+	panicError()
 }

--- a/window.go
+++ b/window.go
@@ -597,7 +597,6 @@ func (w *Window) SetClipboardString(str string) {
 	defer C.free(unsafe.Pointer(cp))
 	C.glfwSetClipboardString(w.data, cp)
 	panicError()
-	return
 }
 
 // GetClipboardString returns the contents of the system clipboard, if it


### PR DESCRIPTION
For details about this solution see the documentation for `acceptError`, `panicError`, and issue #118.
### Present

I fairly confident this change will work appropriately, but I've only tested against my applications. As it's a rather large change, I would appreciate help reviewing / ensuring correctness and testing against any apps you might have.
### Future

`acceptError` will panic on unexpected error codes (ones that are not programmer errors or accepted by the calling function). This ensures that we will be able to catch such errors should we accidentally miss them in the future when updating the 'vendored' GLFW C sources.

I'm confident this change works with GLFW 3.1, but in the future we will need to carefully review changes to the C sources (specifically looking for new places errors might be generated) to ensure that we return them appropriately. 
