### PR TITLE
Allow use of OpenGL ES 2 on Desktop platforms with -tags=gles2

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,12 +1,13 @@
 package glfw3
 
 /*
-// Choose OpenGL client on 386 and amd64.
-#cgo 386 CFLAGS: -D_GLFW_USE_OPENGL
-#cgo amd64 CFLAGS: -D_GLFW_USE_OPENGL
+// Standard OpenGL client is used on 386 and amd64 architectures, except when
+// explicitly asked for gles2 or wayland.
+#cgo 386,!gles2,!wayland CFLAGS: -D_GLFW_USE_OPENGL
+#cgo amd64,!gles2,!wayland CFLAGS: -D_GLFW_USE_OPENGL
 
-// Choose OpenGL ES V2 on arm.
-#cgo arm CFLAGS: -D_GLFW_USE_GLESV2
+// Choose OpenGL ES V2 on arm, or when explicitly asked for gles2/wayland.
+#cgo arm gles2 wayland CFLAGS: -D_GLFW_USE_GLESV2
 
 
 // Windows Build Tags


### PR DESCRIPTION
This allows for the explicitly choosing to use the OpenGL ES 2 client
instead of the standard OpenGL client on Desktop (386, amd64) platforms.

To explicitly choose the OpenGL ES 2 client, use the build tag: `gles2`.
- Additionally: Also choose to use OpenGL ES 2 by default when the `wayland` build tag is present. 
  - We still don't know if `-tags=wayland` builds correctly, but I think this betters the situation as Wayland primarily uses OpenGL ES 2 (not standard OpenGL).
  - If someone cares to test `wayland` later (after merge, or even after 3.1 release) I am willing to do the work to fix whatever might be broken.
