### PR TITLE
Add missing Xinerama to FreeBSD linker options.

### DIFF
--- a/v3.1/glfw/build.go
+++ b/v3.1/glfw/build.go
@@ -46,7 +46,7 @@ package glfw
 #cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND -D_GLFW_EGL -D_GLFW_HAS_DLOPEN
 
 // Linker Options:
-#cgo freebsd,!wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm
-#cgo freebsd,wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm
+#cgo freebsd,!wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm -lXinerama
+#cgo freebsd,wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm -lXinerama
 */
 import "C"


### PR DESCRIPTION
Fixes #131.
