### PR TITLE
README: Update OS X dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 * GLFW C library source is included and built automatically as part of the Go package. But you need to make sure you have dependencies of GLFW:
-	* On OS X, you need Xcode for required headers and libraries.
+	* On OS X, you need Xcode or Command Line Tools for Xcode (`xcode-select --install`) for required headers and libraries.
 	* On Ubuntu/Debian-like Linux distributions, you need `libgl1-mesa-dev` and `xorg-dev` packages.
 	* See [here](http://www.glfw.org/docs/latest/compile.html#compile_deps) for full details.
 * Go 1.4+ is required on Windows (otherwise you must use MinGW v4.8.1 exactly, see [Go issue 8811](https://github.com/golang/go/issues/8811)).


### PR DESCRIPTION
This is a followup to https://github.com/go-gl/glfw/pull/141#discussion_r34961183. As I've learned from a fresh OS X install, either Xcode or Command Line Tools for Xcode are needed.

In fact, it's really hard not to have them already installed by the time you try to build this package on OS X. This is a git repo, and Xcode or CLI for Xcode is the most common way to install `git` on OS X (you get a prompt if you try to run `git` command). Another way to get `git` I know is via Homebrew, but Homebrew itself requires Xcode or CLI for Xcode to function. So by the time you have a working Go environment and this repo cloned, it's likely you'll already have the requirements.

Still, it's good to mention them.

This is similar to requirements for Homebrew:

https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md#requirements

I suppose it might be possible to install `git` on OS X from source (but then you'd need a compiler which is also commonly acquired via Xcode or CLI for Xcode...).
