### PR TITLE
v3.1/glfw: Do not use inline native_darwin.go.

### DIFF
--- a/v3.1/glfw/native_darwin.go
+++ b/v3.1/glfw/native_darwin.go
@@ -8,10 +8,10 @@ package glfw
 
 // workaround wrappers needed due to a cgo and/or LLVM bug.
 // See: https://github.com/go-gl/glfw/issues/136
-inline void *workaround_glfwGetCocoaWindow(GLFWwindow *w) {
+void *workaround_glfwGetCocoaWindow(GLFWwindow *w) {
 	return (void *)glfwGetCocoaWindow(w);
 }
-inline void *workaround_glfwGetNSGLContext(GLFWwindow *w) {
+void *workaround_glfwGetNSGLContext(GLFWwindow *w) {
 	return (void *)glfwGetNSGLContext(w);
 }
 */


### PR DESCRIPTION
Resolves #145.

We want these funcs to be available to Go world via cgo, so they should not be inlined.
