### PR TITLE
#156 - CreateCursor copies pixels off Go space and manually deallocates it after cursor is created.

### DIFF
--- a/v3.1/glfw/input.go
+++ b/v3.1/glfw/input.go
@@ -393,11 +393,11 @@ func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
 		pixels = m.Pix
 	}
 
-	pix, free := strs(string(pixels) + "\x00")
+	pix, free := bytes(pixels)
 
 	img_c.width = C.int(b.Dx())
 	img_c.height = C.int(b.Dy())
-	img_c.pixels = (*C.uchar)(*pix)
+	img_c.pixels = (*C.uchar)(pix)
 
 	c := C.glfwCreateCursor(&img_c, C.int(xhot), C.int(yhot))
 

--- a/v3.1/glfw/util.go
+++ b/v3.1/glfw/util.go
@@ -1,11 +1,53 @@
 package glfw
 
+//#include <stdlib.h>
 //#include "glfw/include/GLFW/glfw3.h"
 import "C"
+
+import (
+	"reflect"
+	"unsafe"
+)
 
 func glfwbool(b C.int) bool {
 	if b == C.GL_TRUE {
 		return true
 	}
 	return false
+}
+
+// strs takes a list of Go strings (with or without null-termination) and
+// returns their C counterpart.
+//
+// The returned free function must be called once you are done using the strings
+// in order to free the memory.
+//
+// If no strings are provided as a parameter this function will panic.
+func strs(strs ...string) (cstrs **uint8, free func()) {
+	if len(strs) == 0 {
+		panic("Strs: expected at least 1 string")
+	}
+
+	// Allocate a contiguous array large enough to hold all the strings' contents.
+	n := 0
+	for i := range strs {
+		n += len(strs[i])
+	}
+	data := C.malloc(C.size_t(n))
+
+	// Copy all the strings into data.
+	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(data),
+		Len:  n,
+		Cap:  n,
+	}))
+	css := make([]*uint8, len(strs)) // Populated with pointers to each string.
+	offset := 0
+	for i := range strs {
+		copy(dataSlice[offset:offset+len(strs[i])], strs[i][:]) // Copy strs[i] into proper data location.
+		css[i] = (*uint8)(unsafe.Pointer(&dataSlice[offset]))   // Set a pointer to it.
+		offset += len(strs[i])
+	}
+
+	return (**uint8)(&css[0]), func() { C.free(data) }
 }

--- a/v3.1/glfw/util.go
+++ b/v3.1/glfw/util.go
@@ -17,20 +17,21 @@ func glfwbool(b C.int) bool {
 }
 
 func bytes(origin []byte) (pointer *uint8, free func()) {
-	if len(origin) == 0 {
-		panic("Slice of bytes cannot be empty.")
+	n := len(origin)
+
+	if n == 0 {
+		return nil, func() {}
 	}
 
-	l := len(origin)
-	d := C.malloc(C.size_t(l))
+	data := C.malloc(C.size_t(n))
 
-	ds := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(d),
-		Len:  l,
-		Cap:  l,
+	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(data),
+		Len:  n,
+		Cap:  n,
 	}))
 
-	copy(ds[0:l], origin[:])
+	copy(dataSlice, origin)
 
-	return (*uint8)(unsafe.Pointer(&ds[0])), func() { C.free(d) }
+	return &dataSlice[0], func() { C.free(data) }
 }

--- a/v3.1/glfw/util.go
+++ b/v3.1/glfw/util.go
@@ -16,38 +16,21 @@ func glfwbool(b C.int) bool {
 	return false
 }
 
-// strs takes a list of Go strings (with or without null-termination) and
-// returns their C counterpart.
-//
-// The returned free function must be called once you are done using the strings
-// in order to free the memory.
-//
-// If no strings are provided as a parameter this function will panic.
-func strs(strs ...string) (cstrs **uint8, free func()) {
-	if len(strs) == 0 {
-		panic("Strs: expected at least 1 string")
+func bytes(origin []byte) (pointer *uint8, free func()) {
+	if len(origin) == 0 {
+		panic("Slice of bytes cannot be empty.")
 	}
 
-	// Allocate a contiguous array large enough to hold all the strings' contents.
-	n := 0
-	for i := range strs {
-		n += len(strs[i])
-	}
-	data := C.malloc(C.size_t(n))
+	l := len(origin)
+	d := C.malloc(C.size_t(l))
 
-	// Copy all the strings into data.
-	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(data),
-		Len:  n,
-		Cap:  n,
+	ds := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(d),
+		Len:  l,
+		Cap:  l,
 	}))
-	css := make([]*uint8, len(strs)) // Populated with pointers to each string.
-	offset := 0
-	for i := range strs {
-		copy(dataSlice[offset:offset+len(strs[i])], strs[i][:]) // Copy strs[i] into proper data location.
-		css[i] = (*uint8)(unsafe.Pointer(&dataSlice[offset]))   // Set a pointer to it.
-		offset += len(strs[i])
-	}
 
-	return (**uint8)(&css[0]), func() { C.free(data) }
+	copy(ds[0:l], origin[:])
+
+	return (*uint8)(unsafe.Pointer(&ds[0])), func() { C.free(d) }
 }

--- a/v3.2/glfw/input.go
+++ b/v3.2/glfw/input.go
@@ -390,23 +390,29 @@ func (w *Window) SetCursorPos(xpos, ypos float64) {
 // Like all other coordinate systems in GLFW, the X-axis points to the right and the Y-axis points down.
 func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
 	var img_c C.GLFWimage
-	var pixPointer *uint8
+	var pixels []uint8
 	b := img.Bounds()
 
 	switch img := img.(type) {
 	case *image.RGBA:
-		pixPointer = &img.Pix[0]
+		pixels = img.Pix
 	default:
 		m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
 		draw.Draw(m, m.Bounds(), img, b.Min, draw.Src)
-		pixPointer = &m.Pix[0]
+		pixels = m.Pix
 	}
+
+	pix, free := strs(string(pixels) + "\x00")
 
 	img_c.width = C.int(b.Dx())
 	img_c.height = C.int(b.Dy())
-	img_c.pixels = (*C.uchar)(pixPointer)
+	img_c.pixels = (*C.uchar)(*pix)
+
 	c := C.glfwCreateCursor(&img_c, C.int(xhot), C.int(yhot))
+
+	free()
 	panicError()
+
 	return &Cursor{c}
 }
 

--- a/v3.2/glfw/input.go
+++ b/v3.2/glfw/input.go
@@ -402,11 +402,11 @@ func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
 		pixels = m.Pix
 	}
 
-	pix, free := strs(string(pixels) + "\x00")
+	pix, free := bytes(pixels)
 
 	img_c.width = C.int(b.Dx())
 	img_c.height = C.int(b.Dy())
-	img_c.pixels = (*C.uchar)(*pix)
+	img_c.pixels = (*C.uchar)(pix)
 
 	c := C.glfwCreateCursor(&img_c, C.int(xhot), C.int(yhot))
 

--- a/v3.2/glfw/util.go
+++ b/v3.2/glfw/util.go
@@ -1,11 +1,53 @@
 package glfw
 
+//#include <stdlib.h>
 //#include "glfw/include/GLFW/glfw3.h"
 import "C"
+
+import (
+	"reflect"
+	"unsafe"
+)
 
 func glfwbool(b C.int) bool {
 	if b == C.GL_TRUE {
 		return true
 	}
 	return false
+}
+
+// strs takes a list of Go strings (with or without null-termination) and
+// returns their C counterpart.
+//
+// The returned free function must be called once you are done using the strings
+// in order to free the memory.
+//
+// If no strings are provided as a parameter this function will panic.
+func strs(strs ...string) (cstrs **uint8, free func()) {
+	if len(strs) == 0 {
+		panic("Strs: expected at least 1 string")
+	}
+
+	// Allocate a contiguous array large enough to hold all the strings' contents.
+	n := 0
+	for i := range strs {
+		n += len(strs[i])
+	}
+	data := C.malloc(C.size_t(n))
+
+	// Copy all the strings into data.
+	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(data),
+		Len:  n,
+		Cap:  n,
+	}))
+	css := make([]*uint8, len(strs)) // Populated with pointers to each string.
+	offset := 0
+	for i := range strs {
+		copy(dataSlice[offset:offset+len(strs[i])], strs[i][:]) // Copy strs[i] into proper data location.
+		css[i] = (*uint8)(unsafe.Pointer(&dataSlice[offset]))   // Set a pointer to it.
+		offset += len(strs[i])
+	}
+
+	return (**uint8)(&css[0]), func() { C.free(data) }
 }

--- a/v3.2/glfw/util.go
+++ b/v3.2/glfw/util.go
@@ -17,20 +17,21 @@ func glfwbool(b C.int) bool {
 }
 
 func bytes(origin []byte) (pointer *uint8, free func()) {
-	if len(origin) == 0 {
-		panic("Slice of bytes cannot be empty.")
+	n := len(origin)
+
+	if n == 0 {
+		return nil, func() {}
 	}
 
-	l := len(origin)
-	d := C.malloc(C.size_t(l))
+	data := C.malloc(C.size_t(n))
 
-	ds := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(d),
-		Len:  l,
-		Cap:  l,
+	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(data),
+		Len:  n,
+		Cap:  n,
 	}))
 
-	copy(ds[0:l], origin[:])
+	copy(dataSlice, origin)
 
-	return (*uint8)(unsafe.Pointer(&ds[0])), func() { C.free(d) }
+	return &dataSlice[0], func() { C.free(data) }
 }

--- a/v3.2/glfw/util.go
+++ b/v3.2/glfw/util.go
@@ -16,38 +16,21 @@ func glfwbool(b C.int) bool {
 	return false
 }
 
-// strs takes a list of Go strings (with or without null-termination) and
-// returns their C counterpart.
-//
-// The returned free function must be called once you are done using the strings
-// in order to free the memory.
-//
-// If no strings are provided as a parameter this function will panic.
-func strs(strs ...string) (cstrs **uint8, free func()) {
-	if len(strs) == 0 {
-		panic("Strs: expected at least 1 string")
+func bytes(origin []byte) (pointer *uint8, free func()) {
+	if len(origin) == 0 {
+		panic("Slice of bytes cannot be empty.")
 	}
 
-	// Allocate a contiguous array large enough to hold all the strings' contents.
-	n := 0
-	for i := range strs {
-		n += len(strs[i])
-	}
-	data := C.malloc(C.size_t(n))
+	l := len(origin)
+	d := C.malloc(C.size_t(l))
 
-	// Copy all the strings into data.
-	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(data),
-		Len:  n,
-		Cap:  n,
+	ds := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(d),
+		Len:  l,
+		Cap:  l,
 	}))
-	css := make([]*uint8, len(strs)) // Populated with pointers to each string.
-	offset := 0
-	for i := range strs {
-		copy(dataSlice[offset:offset+len(strs[i])], strs[i][:]) // Copy strs[i] into proper data location.
-		css[i] = (*uint8)(unsafe.Pointer(&dataSlice[offset]))   // Set a pointer to it.
-		offset += len(strs[i])
-	}
 
-	return (**uint8)(&css[0]), func() { C.free(data) }
+	copy(ds[0:l], origin[:])
+
+	return (*uint8)(unsafe.Pointer(&ds[0])), func() { C.free(d) }
 }


### PR DESCRIPTION
Noticed that while v3.1 passes test (in my internal application), v3.2 is failing on missing c symbols:

> could not determine kind of name for C.glfwGetTimerFrequency
> could not determine kind of name for C.glfwGetTimerValue

I've intentionally ignored this fact since HEAD~1 also fails and it's a development branch.
