### PR TITLE
Travis: Use current stable and previous Go releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ addons:
     - xorg-dev
 language: go
 go:
-  - 1.5.2
+  - 1.7
+  - 1.6.3
   - tip
 matrix:
   allow_failures:


### PR DESCRIPTION
We were testing a really old version of Go 1.5.4, and tip (with allowed failure).

Update to current release of Go (1.7) and previous version (1.6).

This seems reasonable, right? I don't think we should aim to support much more than that, we have very limited resources.
