### PR TITLE
adding mingw deps to build.go for windows

### DIFF
--- a/v3.2/glfw/build.go
+++ b/v3.2/glfw/build.go
@@ -4,7 +4,7 @@ package glfw
 // Windows Build Tags
 // ----------------
 // GLFW Options:
-#cgo windows CFLAGS: -D_GLFW_WIN32
+#cgo windows CFLAGS: -D_GLFW_WIN32 -Iglfw/deps/mingw
 
 // Linker Options:
 #cgo windows LDFLAGS: -lopengl32 -lgdi32


### PR DESCRIPTION
Including the folder `/glfw/deps/mingw` to the build.go file for `dinput.h` issues during `go get` for glfw version 3.2. Fix for issue #179.