### PR TITLE
README: Update OS X name to macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 * GLFW C library source is included and built automatically as part of the Go package. But you need to make sure you have dependencies of GLFW:
-	* On OS X, you need Xcode or Command Line Tools for Xcode (`xcode-select --install`) for required headers and libraries.
+	* On macOS, you need Xcode or Command Line Tools for Xcode (`xcode-select --install`) for required headers and libraries.
 	* On Ubuntu/Debian-like Linux distributions, you need `libgl1-mesa-dev` and `xorg-dev` packages.
 	* On CentOS/Fedora-like Linux distributions, you need `libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel mesa-libGL-devel libXi-devel` packages.
 	* See [here](http://www.glfw.org/docs/latest/compile.html#compile_deps) for full details.


### PR DESCRIPTION
OS X has been renamed to macOS, as of version 10.12. Use its current name.

References:

-	https://www.apple.com/macos
-	https://www.businessinsider.com/wwdc-2016-os-x-becomes-macos-2016-6