### PR TITLE
v3.2/glfw: Accept StandardCursor type in CreateStandardCursor.

### DIFF
--- a/v3.2/glfw/input.go
+++ b/v3.2/glfw/input.go
@@ -425,7 +425,7 @@ func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
 }
 
 // Returns a cursor with a standard shape, that can be set for a window with SetCursor.
-func CreateStandardCursor(shape int) *Cursor {
+func CreateStandardCursor(shape StandardCursor) *Cursor {
 	c := C.glfwCreateStandardCursor(C.int(shape))
 	panicError()
 	return &Cursor{c}


### PR DESCRIPTION
The `StandardCursor` consts are used only for `CreateStandardCursor` method. There's no reason not to accept that type directly.

Fixes #189.