### PR TITLE
v3.2/glfw: Improve docs, fix lint issues.

### DIFF
--- a/v3.2/glfw/context.go
+++ b/v3.2/glfw/context.go
@@ -60,7 +60,7 @@ func SwapInterval(interval int) {
 	panicError()
 }
 
-// ExtensionSupported returns whether the specified OpenGL or context creation
+// ExtensionSupported reports whether the specified OpenGL or context creation
 // API extension is supported by the current context. For example, on Windows
 // both the OpenGL and WGL extension strings are checked.
 //

--- a/v3.2/glfw/glfw.go
+++ b/v3.2/glfw/glfw.go
@@ -3,6 +3,7 @@ package glfw
 //#include "glfw/include/GLFW/glfw3.h"
 import "C"
 
+// Version constants.
 const (
 	VersionMajor    = C.GLFW_VERSION_MAJOR    // This is incremented when the API is changed in non-compatible ways.
 	VersionMinor    = C.GLFW_VERSION_MINOR    // This is incremented when features are added to the API but it remains backward-compatible.

--- a/v3.2/glfw/input.go
+++ b/v3.2/glfw/input.go
@@ -25,7 +25,7 @@ var fJoystickHolder func(joy, event int)
 // Joystick corresponds to a joystick.
 type Joystick int
 
-// Joystick IDs
+// Joystick IDs.
 const (
 	Joystick1    Joystick = C.GLFW_JOYSTICK_1
 	Joystick2    Joystick = C.GLFW_JOYSTICK_2
@@ -180,7 +180,7 @@ const (
 // ModifierKey corresponds to a modifier key.
 type ModifierKey int
 
-// Modifier keys
+// Modifier keys.
 const (
 	ModShift   ModifierKey = C.GLFW_MOD_SHIFT
 	ModControl ModifierKey = C.GLFW_MOD_CONTROL
@@ -191,7 +191,7 @@ const (
 // MouseButton corresponds to a mouse button.
 type MouseButton int
 
-// Mouse buttons
+// Mouse buttons.
 const (
 	MouseButton1      MouseButton = C.GLFW_MOUSE_BUTTON_1
 	MouseButton2      MouseButton = C.GLFW_MOUSE_BUTTON_2
@@ -223,6 +223,7 @@ const (
 // Action corresponds to a key or button action.
 type Action int
 
+// Action types.
 const (
 	Release Action = C.GLFW_RELEASE // The key or button was released.
 	Press   Action = C.GLFW_PRESS   // The key or button was pressed.
@@ -232,20 +233,21 @@ const (
 // InputMode corresponds to an input mode.
 type InputMode int
 
-// Input modes
+// Input modes.
 const (
 	CursorMode             InputMode = C.GLFW_CURSOR               // See Cursor mode values
 	StickyKeysMode         InputMode = C.GLFW_STICKY_KEYS          // Value can be either 1 or 0
 	StickyMouseButtonsMode InputMode = C.GLFW_STICKY_MOUSE_BUTTONS // Value can be either 1 or 0
 )
 
-// Cursor mode values
+// Cursor mode values.
 const (
 	CursorNormal   int = C.GLFW_CURSOR_NORMAL
 	CursorHidden   int = C.GLFW_CURSOR_HIDDEN
 	CursorDisabled int = C.GLFW_CURSOR_DISABLED
 )
 
+// Cursor represents a cursor.
 type Cursor struct {
 	data *C.GLFWcursor
 }
@@ -317,7 +319,7 @@ func (w *Window) GetInputMode(mode InputMode) int {
 	return ret
 }
 
-// Sets an input option for the window.
+// SetInputMode sets an input option for the window.
 func (w *Window) SetInputMode(mode InputMode, value int) {
 	C.glfwSetInputMode(w.data, C.int(mode), C.int(value))
 	panicError()
@@ -386,7 +388,7 @@ func (w *Window) SetCursorPos(xpos, ypos float64) {
 	panicError()
 }
 
-// Creates a new custom cursor image that can be set for a window with SetCursor.
+// CreateCursor creates a new custom cursor image that can be set for a window with SetCursor.
 // The cursor can be destroyed with Destroy. Any remaining cursors are destroyed by Terminate.
 //
 // The pixels are 32-bit little-endian RGBA, i.e. eight bits per channel. They are arranged
@@ -397,7 +399,7 @@ func (w *Window) SetCursorPos(xpos, ypos float64) {
 // The cursor hotspot is specified in pixels, relative to the upper-left corner of the cursor image.
 // Like all other coordinate systems in GLFW, the X-axis points to the right and the Y-axis points down.
 func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
-	var img_c C.GLFWimage
+	var imgC C.GLFWimage
 	var pixels []uint8
 	b := img.Bounds()
 
@@ -412,11 +414,11 @@ func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
 
 	pix, free := bytes(pixels)
 
-	img_c.width = C.int(b.Dx())
-	img_c.height = C.int(b.Dy())
-	img_c.pixels = (*C.uchar)(pix)
+	imgC.width = C.int(b.Dx())
+	imgC.height = C.int(b.Dy())
+	imgC.pixels = (*C.uchar)(pix)
 
-	c := C.glfwCreateCursor(&img_c, C.int(xhot), C.int(yhot))
+	c := C.glfwCreateCursor(&imgC, C.int(xhot), C.int(yhot))
 
 	free()
 	panicError()
@@ -424,21 +426,22 @@ func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
 	return &Cursor{c}
 }
 
-// Returns a cursor with a standard shape, that can be set for a window with SetCursor.
+// CreateStandardCursor returns a cursor with a standard shape,
+// that can be set for a window with SetCursor.
 func CreateStandardCursor(shape StandardCursor) *Cursor {
 	c := C.glfwCreateStandardCursor(C.int(shape))
 	panicError()
 	return &Cursor{c}
 }
 
-// This function destroys a cursor previously created with CreateCursor.
+// Destroy destroys a cursor previously created with CreateCursor.
 // Any remaining cursors will be destroyed by Terminate.
 func (c *Cursor) Destroy() {
 	C.glfwDestroyCursor(c.data)
 	panicError()
 }
 
-// This function sets the cursor image to be used when the cursor is over the client area
+// SetCursor sets the cursor image to be used when the cursor is over the client area
 // of the specified window. The set cursor will only be visible when the cursor mode of the
 // window is CursorNormal.
 //
@@ -452,6 +455,7 @@ func (w *Window) SetCursor(c *Cursor) {
 	panicError()
 }
 
+// JoystickCallback is the joystick configuration callback.
 type JoystickCallback func(joy, event int)
 
 // SetJoystickCallback sets the joystick configuration callback, or removes the
@@ -469,6 +473,7 @@ func SetJoystickCallback(cbfun JoystickCallback) (previous JoystickCallback) {
 	return previous
 }
 
+// KeyCallback is the key callback.
 type KeyCallback func(w *Window, key Key, scancode int, action Action, mods ModifierKey)
 
 // SetKeyCallback sets the key callback which is called when a key is pressed,
@@ -495,6 +500,7 @@ func (w *Window) SetKeyCallback(cbfun KeyCallback) (previous KeyCallback) {
 	return previous
 }
 
+// CharCallback is the character callback.
 type CharCallback func(w *Window, char rune)
 
 // SetCharCallback sets the character callback which is called when a
@@ -523,6 +529,7 @@ func (w *Window) SetCharCallback(cbfun CharCallback) (previous CharCallback) {
 	return previous
 }
 
+// CharModsCallback is the character with modifiers callback.
 type CharModsCallback func(w *Window, char rune, mods ModifierKey)
 
 // SetCharModsCallback sets the character with modifiers callback which is called when a
@@ -547,6 +554,7 @@ func (w *Window) SetCharModsCallback(cbfun CharModsCallback) (previous CharModsC
 	return previous
 }
 
+// MouseButtonCallback is the mouse button callback.
 type MouseButtonCallback func(w *Window, button MouseButton, action Action, mod ModifierKey)
 
 // SetMouseButtonCallback sets the mouse button callback which is called when a
@@ -569,6 +577,7 @@ func (w *Window) SetMouseButtonCallback(cbfun MouseButtonCallback) (previous Mou
 	return previous
 }
 
+// CursorPosCallback the cursor position callback.
 type CursorPosCallback func(w *Window, xpos float64, ypos float64)
 
 // SetCursorPosCallback sets the cursor position callback which is called
@@ -586,6 +595,7 @@ func (w *Window) SetCursorPosCallback(cbfun CursorPosCallback) (previous CursorP
 	return previous
 }
 
+// CursorEnterCallback is the cursor boundary crossing callback.
 type CursorEnterCallback func(w *Window, entered bool)
 
 // SetCursorEnterCallback the cursor boundary crossing callback which is called
@@ -602,6 +612,7 @@ func (w *Window) SetCursorEnterCallback(cbfun CursorEnterCallback) (previous Cur
 	return previous
 }
 
+// ScrollCallback is the scroll callback.
 type ScrollCallback func(w *Window, xoff float64, yoff float64)
 
 // SetScrollCallback sets the scroll callback which is called when a scrolling
@@ -618,6 +629,7 @@ func (w *Window) SetScrollCallback(cbfun ScrollCallback) (previous ScrollCallbac
 	return previous
 }
 
+// DropCallback is the drop callback.
 type DropCallback func(w *Window, names []string)
 
 // SetDropCallback sets the drop callback which is called when an object
@@ -634,7 +646,7 @@ func (w *Window) SetDropCallback(cbfun DropCallback) (previous DropCallback) {
 	return previous
 }
 
-// GetJoystickPresent returns whether the specified joystick is present.
+// JoystickPresent reports whether the specified joystick is present.
 func JoystickPresent(joy Joystick) bool {
 	ret := glfwbool(C.glfwJoystickPresent(C.int(joy)))
 	panicError()

--- a/v3.2/glfw/monitor.go
+++ b/v3.2/glfw/monitor.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 )
 
+// Monitor represents a monitor.
 type Monitor struct {
 	data *C.GLFWmonitor
 }

--- a/v3.2/glfw/native_darwin.go
+++ b/v3.2/glfw/native_darwin.go
@@ -17,18 +17,21 @@ void *workaround_glfwGetNSGLContext(GLFWwindow *w) {
 */
 import "C"
 
+// GetCocoaMonitor returns the CGDirectDisplayID of the monitor.
 func (m *Monitor) GetCocoaMonitor() uintptr {
 	ret := uintptr(C.glfwGetCocoaMonitor(m.data))
 	panicError()
 	return ret
 }
 
+// GetCocoaWindow returns the NSWindow of the window.
 func (w *Window) GetCocoaWindow() uintptr {
 	ret := uintptr(C.workaround_glfwGetCocoaWindow(w.data))
 	panicError()
 	return ret
 }
 
+// GetNSGLContext returns the NSOpenGLContext of the window.
 func (w *Window) GetNSGLContext() uintptr {
 	ret := uintptr(C.workaround_glfwGetNSGLContext(w.data))
 	panicError()

--- a/v3.2/glfw/native_linbsd.go
+++ b/v3.2/glfw/native_linbsd.go
@@ -14,30 +14,35 @@ func GetX11Display() *C.Display {
 	return ret
 }
 
+// GetX11Adapter returns the RRCrtc of the monitor.
 func (m *Monitor) GetX11Adapter() C.RRCrtc {
 	ret := C.glfwGetX11Adapter(m.data)
 	panicError()
 	return ret
 }
 
+// GetX11Monitor returns the RROutput of the monitor.
 func (m *Monitor) GetX11Monitor() C.RROutput {
 	ret := C.glfwGetX11Monitor(m.data)
 	panicError()
 	return ret
 }
 
+// GetX11Window returns the Window of the window.
 func (w *Window) GetX11Window() C.Window {
 	ret := C.glfwGetX11Window(w.data)
 	panicError()
 	return ret
 }
 
+// GetGLXContext returns the GLXContext of the window.
 func (w *Window) GetGLXContext() C.GLXContext {
 	ret := C.glfwGetGLXContext(w.data)
 	panicError()
 	return ret
 }
 
+// GetGLXWindow returns the GLXWindow of the window.
 func (w *Window) GetGLXWindow() C.GLXWindow {
 	ret := C.glfwGetGLXWindow(w.data)
 	panicError()

--- a/v3.2/glfw/native_windows.go
+++ b/v3.2/glfw/native_windows.go
@@ -6,24 +6,28 @@ package glfw
 //#include "glfw/include/GLFW/glfw3native.h"
 import "C"
 
+// GetWin32Adapter returns the adapter device name of the monitor.
 func (m *Monitor) GetWin32Adapter() string {
 	ret := C.glfwGetWin32Adapter(m.data)
 	panicError()
 	return C.GoString(ret)
 }
 
+// GetWin32Monitor returns the display device name of the monitor.
 func (m *Monitor) GetWin32Monitor() string {
 	ret := C.glfwGetWin32Monitor(m.data)
 	panicError()
 	return C.GoString(ret)
 }
 
+// GetWin32Window returns the HWND of the window.
 func (w *Window) GetWin32Window() C.HWND {
 	ret := C.glfwGetWin32Window(w.data)
 	panicError()
 	return ret
 }
 
+// GetWGLContext returns the HGLRC of the window.
 func (w *Window) GetWGLContext() C.HGLRC {
 	ret := C.glfwGetWGLContext(w.data)
 	panicError()

--- a/v3.2/glfw/vulkan.go
+++ b/v3.2/glfw/vulkan.go
@@ -3,7 +3,7 @@ package glfw
 //#include "glfw/include/GLFW/glfw3.h"
 import "C"
 
-// VulkanSupported returns whether the Vulkan loader has been found. This check is performed by Init.
+// VulkanSupported reports whether the Vulkan loader has been found. This check is performed by Init.
 //
 // The availability of a Vulkan loader does not by itself guarantee that window surface creation or
 // even device creation is possible. Call GetRequiredInstanceExtensions to check whether the

--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -136,10 +136,11 @@ const (
 	DontCare int = C.GLFW_DONT_CARE
 )
 
+// Window represents a window.
 type Window struct {
 	data *C.GLFWwindow
 
-	// Window
+	// Window.
 	fPosHolder             func(w *Window, xpos int, ypos int)
 	fSizeHolder            func(w *Window, width int, height int)
 	fFramebufferSizeHolder func(w *Window, width int, height int)
@@ -148,7 +149,7 @@ type Window struct {
 	fFocusHolder           func(w *Window, focused bool)
 	fIconifyHolder         func(w *Window, iconified bool)
 
-	// Input
+	// Input.
 	fMouseButtonHolder func(w *Window, button MouseButton, action Action, mod ModifierKey)
 	fCursorPosHolder   func(w *Window, xpos float64, ypos float64)
 	fCursorEnterHolder func(w *Window, entered bool)
@@ -209,7 +210,7 @@ func goWindowIconifyCB(window unsafe.Pointer, iconified C.int) {
 	w.fIconifyHolder(w, isIconified)
 }
 
-// DefaultHints resets all window hints to their default values.
+// DefaultWindowHints resets all window hints to their default values.
 //
 // This function may only be called from the main thread.
 func DefaultWindowHints() {
@@ -217,9 +218,9 @@ func DefaultWindowHints() {
 	panicError()
 }
 
-// Hint function sets hints for the next call to CreateWindow. The hints,
-// once set, retain their values until changed by a call to Hint or
-// DefaultHints, or until the library is terminated with Terminate.
+// WindowHint sets hints for the next call to CreateWindow. The hints,
+// once set, retain their values until changed by a call to WindowHint or
+// DefaultWindowHints, or until the library is terminated with Terminate.
 //
 // This function may only be called from the main thread.
 func WindowHint(target Hint, hint int) {
@@ -295,7 +296,7 @@ func (w *Window) Destroy() {
 	panicError()
 }
 
-// ShouldClose returns the value of the close flag of the specified window.
+// ShouldClose reports the value of the close flag of the specified window.
 func (w *Window) ShouldClose() bool {
 	ret := glfwbool(C.glfwWindowShouldClose(w.data))
 	panicError()
@@ -475,7 +476,7 @@ func (w *Window) Focus() error {
 	return acceptError(APIUnavailable)
 }
 
-// Iconfiy iconifies/minimizes the window, if it was previously restored. If it
+// Iconify iconifies/minimizes the window, if it was previously restored. If it
 // is a full screen window, the original monitor resolution is restored until the
 // window is restored. If the window is already iconified, this function does
 // nothing.
@@ -586,6 +587,7 @@ func (w *Window) GetUserPointer() unsafe.Pointer {
 	return ret
 }
 
+// PosCallback is the window position callback.
 type PosCallback func(w *Window, xpos int, ypos int)
 
 // SetPosCallback sets the position callback of the window, which is called
@@ -603,6 +605,7 @@ func (w *Window) SetPosCallback(cbfun PosCallback) (previous PosCallback) {
 	return previous
 }
 
+// SizeCallback is the window size callback.
 type SizeCallback func(w *Window, width int, height int)
 
 // SetSizeCallback sets the size callback of the window, which is called when
@@ -620,6 +623,7 @@ func (w *Window) SetSizeCallback(cbfun SizeCallback) (previous SizeCallback) {
 	return previous
 }
 
+// FramebufferSizeCallback is the framebuffer size callback.
 type FramebufferSizeCallback func(w *Window, width int, height int)
 
 // SetFramebufferSizeCallback sets the framebuffer resize callback of the specified
@@ -636,6 +640,7 @@ func (w *Window) SetFramebufferSizeCallback(cbfun FramebufferSizeCallback) (prev
 	return previous
 }
 
+// CloseCallback is the window close callback.
 type CloseCallback func(w *Window)
 
 // SetCloseCallback sets the close callback of the window, which is called when
@@ -659,6 +664,7 @@ func (w *Window) SetCloseCallback(cbfun CloseCallback) (previous CloseCallback) 
 	return previous
 }
 
+// RefreshCallback is the window refresh callback.
 type RefreshCallback func(w *Window)
 
 // SetRefreshCallback sets the refresh callback of the window, which
@@ -680,6 +686,7 @@ func (w *Window) SetRefreshCallback(cbfun RefreshCallback) (previous RefreshCall
 	return previous
 }
 
+// FocusCallback is the window focus callback.
 type FocusCallback func(w *Window, focused bool)
 
 // SetFocusCallback sets the focus callback of the window, which is called when
@@ -700,6 +707,7 @@ func (w *Window) SetFocusCallback(cbfun FocusCallback) (previous FocusCallback) 
 	return previous
 }
 
+// IconifyCallback is the window iconification callback.
 type IconifyCallback func(w *Window, iconified bool)
 
 // SetIconifyCallback sets the iconification callback of the window, which is


### PR DESCRIPTION
Use "reports whether" instead of "returns" for funcs that return bool values. This is more idiomatic and readable.

Fix typos, missing documentation for exported symbols, missing periods.

This change fixes the following lint issues detected by golint:

	$ golint ./v3.2/glfw
	v3.2/glfw/glfw.go:7:2: exported const VersionMajor should have comment (or a comment on this block) or be unexported
	v3.2/glfw/input.go:227:2: exported const Release should have comment (or a comment on this block) or be unexported
	v3.2/glfw/input.go:249:6: exported type Cursor should have comment or be unexported
	v3.2/glfw/input.go:320:1: comment on exported method Window.SetInputMode should be of the form "SetInputMode ..."
	v3.2/glfw/input.go:389:1: comment on exported function CreateCursor should be of the form "CreateCursor ..."
	v3.2/glfw/input.go:400:6: don't use underscores in Go names; var img_c should be imgC
	v3.2/glfw/input.go:427:1: comment on exported function CreateStandardCursor should be of the form "CreateStandardCursor ..."
	v3.2/glfw/input.go:434:1: comment on exported method Cursor.Destroy should be of the form "Destroy ..."
	v3.2/glfw/input.go:441:1: comment on exported method Window.SetCursor should be of the form "SetCursor ..."
	v3.2/glfw/input.go:455:6: exported type JoystickCallback should have comment or be unexported
	v3.2/glfw/input.go:472:6: exported type KeyCallback should have comment or be unexported
	v3.2/glfw/input.go:498:6: exported type CharCallback should have comment or be unexported
	v3.2/glfw/input.go:526:6: exported type CharModsCallback should have comment or be unexported
	v3.2/glfw/input.go:550:6: exported type MouseButtonCallback should have comment or be unexported
	v3.2/glfw/input.go:572:6: exported type CursorPosCallback should have comment or be unexported
	v3.2/glfw/input.go:589:6: exported type CursorEnterCallback should have comment or be unexported
	v3.2/glfw/input.go:605:6: exported type ScrollCallback should have comment or be unexported
	v3.2/glfw/input.go:621:6: exported type DropCallback should have comment or be unexported
	v3.2/glfw/input.go:637:1: comment on exported function JoystickPresent should be of the form "JoystickPresent ..."
	v3.2/glfw/monitor.go:15:6: exported type Monitor should have comment or be unexported
	v3.2/glfw/native_darwin.go:20:1: exported method Monitor.GetCocoaMonitor should have comment or be unexported
	v3.2/glfw/native_darwin.go:26:1: exported method Window.GetCocoaWindow should have comment or be unexported
	v3.2/glfw/native_darwin.go:32:1: exported method Window.GetNSGLContext should have comment or be unexported
	v3.2/glfw/window.go:139:6: exported type Window should have comment or be unexported
	v3.2/glfw/window.go:212:1: comment on exported function DefaultWindowHints should be of the form "DefaultWindowHints ..."
	v3.2/glfw/window.go:220:1: comment on exported function WindowHint should be of the form "WindowHint ..."
	v3.2/glfw/window.go:478:1: comment on exported method Window.Iconify should be of the form "Iconify ..."
	v3.2/glfw/window.go:589:6: exported type PosCallback should have comment or be unexported
	v3.2/glfw/window.go:606:6: exported type SizeCallback should have comment or be unexported
	v3.2/glfw/window.go:623:6: exported type FramebufferSizeCallback should have comment or be unexported
	v3.2/glfw/window.go:639:6: exported type CloseCallback should have comment or be unexported
	v3.2/glfw/window.go:662:6: exported type RefreshCallback should have comment or be unexported
	v3.2/glfw/window.go:683:6: exported type FocusCallback should have comment or be unexported
	v3.2/glfw/window.go:703:6: exported type IconifyCallback should have comment or be unexported