### PR TITLE
v3.2/glfw: Fix Window.SetIcon handling of empty slice.

### DIFF
--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -357,7 +357,11 @@ func (w *Window) SetIcon(images []image.Image) {
 		cimages[i].pixels = (*C.uchar)(pix)
 	}
 
-	C.glfwSetWindowIcon(w.data, C.int(count), &cimages[0])
+	var p *C.GLFWimage
+	if count > 0 {
+		p = &cimages[0]
+	}
+	C.glfwSetWindowIcon(w.data, C.int(count), p)
 
 	for _, v := range freePixels {
 		v()


### PR DESCRIPTION
Window.SetIcon method is documented as:

	If no images are specified, the window reverts to its default icon.

Fix an index out of range panic when no images are provided. Use a null pointer in `C.glfwSetWindowIcon` call instead.

Fixes #193.