### PR TITLE
v3.2/glfw: Use and document *image.NRGBA as expected image format.

### DIFF
--- a/v3.2/glfw/input.go
+++ b/v3.2/glfw/input.go
@@ -391,10 +391,11 @@ func (w *Window) SetCursorPos(xpos, ypos float64) {
 // CreateCursor creates a new custom cursor image that can be set for a window with SetCursor.
 // The cursor can be destroyed with Destroy. Any remaining cursors are destroyed by Terminate.
 //
+// The image is ideally provided in the form of *image.NRGBA.
 // The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
 // bits per channel with the red channel first. They are arranged canonically
 // as packed sequential rows, starting from the top-left corner. If the image
-// type is not already *image.NRGBA, it will be converted.
+// type is not *image.NRGBA, it will be converted to it.
 //
 // The cursor hotspot is specified in pixels, relative to the upper-left corner of the cursor image.
 // Like all other coordinate systems in GLFW, the X-axis points to the right and the Y-axis points down.

--- a/v3.2/glfw/input.go
+++ b/v3.2/glfw/input.go
@@ -391,10 +391,10 @@ func (w *Window) SetCursorPos(xpos, ypos float64) {
 // CreateCursor creates a new custom cursor image that can be set for a window with SetCursor.
 // The cursor can be destroyed with Destroy. Any remaining cursors are destroyed by Terminate.
 //
-// The pixels are 32-bit little-endian RGBA, i.e. eight bits per channel. They are arranged
-// canonically as packed sequential rows, starting from the top-left corner.
-//
-// All non-RGBA images will be converted to RGBA.
+// The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
+// bits per channel with the red channel first. They are arranged canonically
+// as packed sequential rows, starting from the top-left corner. If the image
+// type is not already *image.NRGBA, it will be converted.
 //
 // The cursor hotspot is specified in pixels, relative to the upper-left corner of the cursor image.
 // Like all other coordinate systems in GLFW, the X-axis points to the right and the Y-axis points down.
@@ -404,10 +404,10 @@ func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
 	b := img.Bounds()
 
 	switch img := img.(type) {
-	case *image.RGBA:
+	case *image.NRGBA:
 		pixels = img.Pix
 	default:
-		m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+		m := image.NewNRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
 		draw.Draw(m, m.Bounds(), img, b.Min, draw.Src)
 		pixels = m.Pix
 	}

--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -330,6 +330,11 @@ func (w *Window) SetTitle(title string) {
 // those of or closest to the sizes desired by the system are selected. If no images are
 // specified, the window reverts to its default icon.
 //
+// The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
+// bits per channel with the red channel first. They are arranged canonically
+// as packed sequential rows, starting from the top-left corner. If the image
+// type is not already *image.NRGBA, it will be converted.
+//
 // The desired image sizes varies depending on platform and system settings. The selected
 // images will be rescaled as needed. Good sizes include 16x16, 32x32 and 48x48.
 func (w *Window) SetIcon(images []image.Image) {
@@ -342,10 +347,10 @@ func (w *Window) SetIcon(images []image.Image) {
 		b := img.Bounds()
 
 		switch img := img.(type) {
-		case *image.RGBA:
+		case *image.NRGBA:
 			pixels = img.Pix
 		default:
-			m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+			m := image.NewNRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
 			draw.Draw(m, m.Bounds(), img, b.Min, draw.Src)
 			pixels = m.Pix
 		}

--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -330,10 +330,11 @@ func (w *Window) SetTitle(title string) {
 // those of or closest to the sizes desired by the system are selected. If no images are
 // specified, the window reverts to its default icon.
 //
+// The image is ideally provided in the form of *image.NRGBA.
 // The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
 // bits per channel with the red channel first. They are arranged canonically
 // as packed sequential rows, starting from the top-left corner. If the image
-// type is not already *image.NRGBA, it will be converted.
+// type is not *image.NRGBA, it will be converted to it.
 //
 // The desired image sizes varies depending on platform and system settings. The selected
 // images will be rescaled as needed. Good sizes include 16x16, 32x32 and 48x48.


### PR DESCRIPTION
GLFW images are non-premultiplied RGBA, which corresponds to `*image.NRGBA` type. This was previously not documented in GLFW, but has since been fixed in glfw/glfw#426 and glfw/glfw#1027.

This is not a breaking API change and functionality is preserved. However, for optimal performance (to avoid unnecessary conversions), images should now ideally be provided as `*image.NRGBA` rather than `*image.RGBA`.

Fixes #209. /cc @hajimehoshi