### PR TITLE
v3.2/glfw: Suggest native Go primitives for synchronization.

### DIFF
--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -803,7 +803,7 @@ func WaitEvents() {
 // processing functions.
 //
 // If no windows exist, this function returns immediately. For synchronization of threads in
-// applications that do not create windows, use your threading library of choice.
+// applications that do not create windows, use native Go primitives.
 //
 // Event processing is not required for joystick input to work.
 func WaitEventsTimeout(timeout float64) {
@@ -814,9 +814,8 @@ func WaitEventsTimeout(timeout float64) {
 // PostEmptyEvent posts an empty event from the current thread to the main
 // thread event queue, causing WaitEvents to return.
 //
-// If no windows exist, this function returns immediately.  For
-// synchronization of threads in applications that do not create windows, use
-// your threading library of choice.
+// If no windows exist, this function returns immediately. For synchronization of threads in
+// applications that do not create windows, use native Go primitives.
 //
 // This function may be called from secondary threads.
 func PostEmptyEvent() {


### PR DESCRIPTION
The original text was taken from GLFW (C library) documentation. Given GLFW is written in C, and there is no clear best choice of a threading library and it's not built into the language, the wording made sense.

In Go, there's a clear solution provided by the programming language, so we can suggest using it directly. (/cc @elmindreda This is one of those reasons I really enjoy Go. ☺️)

Also improve formatting (use [single space between sentences](https://dmitri.shuralyov.com/idiomatic-go#single-spaces-between-sentences), which is consistent with Go style).