### PR TITLE
glfw fails to build on FreeBSD, fix

### DIFF
--- a/v3.2/glfw/build.go
+++ b/v3.2/glfw/build.go
@@ -35,6 +35,7 @@ package glfw
 // GLFW Options:
 #cgo freebsd,!wayland CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB -D_GLFW_HAS_DLOPEN
 #cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND -D_GLFW_HAS_DLOPEN
+#cgo linux freebsd pkg-config: gl
 
 // Linker Options:
 #cgo freebsd,!wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm -lXinerama


### PR DESCRIPTION
Build fails with the following :
```
undef@lenovo:~/go/src/github.com/go-gl/glfw/v3.2/glfw % go build
# github.com/go-gl/glfw/v3.2/glfw
In file included from ./c_glfw.go:4:
In file included from ./glfw/src/context.c:28:
In file included from ./glfw/src/internal.h:169:
./glfw/src/x11_platform.h:36:10: fatal error: 'X11/Xlib.h' file not found
#include <X11/Xlib.h>
         ^~~~~~~~~~~~
1 error generated.
```

After adding line:
#cgo linux freebsd pkg-config: gl

Build now works.