### PR TITLE
v3.2/glfw: Create a glfw.Window from a *C.GLFWwindow reference

### DIFF
--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -169,9 +169,8 @@ func (w *Window) GLFWWindow() uintptr {
 
 // GoWindow creates a Window from a *C.GLFWwindow reference.
 // Used when an external C library is calling your Go handlers.
-func GoWindow(window uintptr) *Window {
-	w := (*C.GLFWwindow)(unsafe.Pointer(window))
-	return &Window{data: w}
+func GoWindow(window unsafe.Pointer) *Window {
+	return &Window{data: (*C.GLFWwindow)(window)}
 }
 
 //export goWindowPosCB

--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -167,6 +167,12 @@ func (w *Window) GLFWWindow() uintptr {
 	return uintptr(unsafe.Pointer(w.data))
 }
 
+// GoWindow creates a Window from a *C.GLFWwindow reference.
+// Used when an external C library is calling your Go handlers.
+func GoWindow(w unsafe.Pointer) *Window {
+	return &Window{data: (*_Ctype_struct_GLFWwindow)(w)}
+}
+
 //export goWindowPosCB
 func goWindowPosCB(window unsafe.Pointer, xpos, ypos C.int) {
 	w := windows.get((*C.GLFWwindow)(window))

--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -169,8 +169,9 @@ func (w *Window) GLFWWindow() uintptr {
 
 // GoWindow creates a Window from a *C.GLFWwindow reference.
 // Used when an external C library is calling your Go handlers.
-func GoWindow(w unsafe.Pointer) *Window {
-	return &Window{data: (*_Ctype_struct_GLFWwindow)(w)}
+func GoWindow(window uintptr) *Window {
+	w := (*C.GLFWwindow)(unsafe.Pointer(window))
+	return &Window{data: w}
 }
 
 //export goWindowPosCB


### PR DESCRIPTION
Bring back the glfw.Window. Opposite of #173