### PR TITLE
add updateNSGLContext before poll events

### DIFF
--- a/v3.1/glfw/context.go
+++ b/v3.1/glfw/context.go
@@ -37,6 +37,7 @@ func GetCurrentContext() *Window {
 // swap interval is greater than zero, the GPU driver waits the specified number
 // of screen updates before swapping the buffers.
 func (w *Window) SwapBuffers() {
+	w.updateNSGLContext()
 	C.glfwSwapBuffers(w.data)
 	panicError()
 }

--- a/v3.1/glfw/native_linbsd.go
+++ b/v3.1/glfw/native_linbsd.go
@@ -25,3 +25,5 @@ func GetX11Display() *C.Display {
 	panicError()
 	return ret
 }
+
+func (w *Window) updateNSGLContext() {}

--- a/v3.1/glfw/native_windows.go
+++ b/v3.1/glfw/native_windows.go
@@ -17,3 +17,5 @@ func (w *Window) GetWGLContext() C.HGLRC {
 	panicError()
 	return ret
 }
+
+func (w *Window) updateNSGLContext() {}

--- a/v3.2/glfw/context.go
+++ b/v3.2/glfw/context.go
@@ -37,6 +37,7 @@ func GetCurrentContext() *Window {
 // swap interval is greater than zero, the GPU driver waits the specified number
 // of screen updates before swapping the buffers.
 func (w *Window) SwapBuffers() {
+	w.updateNSGLContext()
 	C.glfwSwapBuffers(w.data)
 	panicError()
 }

--- a/v3.2/glfw/native_darwin.go
+++ b/v3.2/glfw/native_darwin.go
@@ -14,8 +14,15 @@ void *workaround_glfwGetCocoaWindow(GLFWwindow *w) {
 void *workaround_glfwGetNSGLContext(GLFWwindow *w) {
 	return (void *)glfwGetNSGLContext(w);
 }
+// workaround for inability to draw at start of program in OSX Mojave
+// See: https://github.com/glfw/glfw/issues/1334
+void cocoa_update_nsgl_context(void* id) {
+    NSOpenGLContext *ctx = id;
+    [ctx update];
+}
 */
 import "C"
+import "unsafe"
 
 // GetCocoaMonitor returns the CGDirectDisplayID of the monitor.
 func (m *Monitor) GetCocoaMonitor() uintptr {
@@ -36,4 +43,14 @@ func (w *Window) GetNSGLContext() uintptr {
 	ret := uintptr(C.workaround_glfwGetNSGLContext(w.data))
 	panicError()
 	return ret
+}
+
+var numUpdates int
+
+func (w *Window) updateNSGLContext() {
+	if numUpdates < 2 {
+		ctx := w.GetNSGLContext()
+		C.cocoa_update_nsgl_context(unsafe.Pointer(ctx))
+		numUpdates++
+	}
 }

--- a/v3.2/glfw/native_linbsd.go
+++ b/v3.2/glfw/native_linbsd.go
@@ -48,3 +48,5 @@ func (w *Window) GetGLXWindow() C.GLXWindow {
 	panicError()
 	return ret
 }
+
+func (w *Window) updateNSGLContext() {}

--- a/v3.2/glfw/native_windows.go
+++ b/v3.2/glfw/native_windows.go
@@ -33,3 +33,5 @@ func (w *Window) GetWGLContext() C.HGLRC {
 	panicError()
 	return ret
 }
+
+func (w *Window) updateNSGLContext() {}


### PR DESCRIPTION
fixes #228

Tested on glfw 3.1 and 3.2 on both OSX High Sierra and OSX Mojave.  