### PR TITLE
freebsd: Fix build

### DIFF
--- a/v3.2/glfw/build.go
+++ b/v3.2/glfw/build.go
@@ -33,11 +33,13 @@ package glfw
 // FreeBSD Build Tags
 // ----------------
 // GLFW Options:
-#cgo freebsd,!wayland CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB -D_GLFW_HAS_DLOPEN
-#cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND -D_GLFW_HAS_DLOPEN
+#cgo freebsd pkg-config: glfw3
+#cgo freebsd CFLAGS: -D_GLFW_HAS_DLOPEN
+#cgo freebsd,!wayland CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
+#cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND
 
 // Linker Options:
-#cgo freebsd,!wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm -lXinerama
-#cgo freebsd,wayland LDFLAGS: -lGL -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon -lm
+#cgo freebsd,!wayland LDFLAGS: -lm -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lXinerama
+#cgo freebsd,wayland LDFLAGS: -lm -lGL -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
 */
 import "C"


### PR DESCRIPTION
Use pkg-config to fix the FreeBSD build. This is a minimal change for now since I just wanted to get FreeBSD building. I'm tempted to do a follow-up that unifies the Linux options and uses pkg-config for all the library dependencies.

See also go-gl/glow#103 and go-gl/gl#117