### PR TITLE
Windows multihead and hidpi cursor icons support patch

### DIFF
--- a/v3.2/glfw/glfw/src/init.c
+++ b/v3.2/glfw/glfw/src/init.c
@@ -130,6 +130,9 @@ GLFWAPI int glfwInit(void)
         return GLFW_FALSE;
     }
 
+#ifndef _GLFW_WIN32
+    _glfw.monitors = _glfwPlatformGetMonitors(&_glfw.monitorCount);
+#endif
     _glfwInitialized = GLFW_TRUE;
 
     _glfw.timerOffset = _glfwPlatformGetTimerValue();

--- a/v3.2/glfw/glfw/src/init.c
+++ b/v3.2/glfw/glfw/src/init.c
@@ -130,7 +130,6 @@ GLFWAPI int glfwInit(void)
         return GLFW_FALSE;
     }
 
-    _glfw.monitors = _glfwPlatformGetMonitors(&_glfw.monitorCount);
     _glfwInitialized = GLFW_TRUE;
 
     _glfw.timerOffset = _glfwPlatformGetTimerValue();

--- a/v3.2/glfw/glfw/src/internal.h
+++ b/v3.2/glfw/glfw/src/internal.h
@@ -48,6 +48,9 @@
 #define GLFW_INCLUDE_NONE
 #include "../include/GLFW/glfw3.h"
 
+#define _GLFW_INSERT_FIRST      0
+#define _GLFW_INSERT_LAST       1
+
 typedef int GLFWbool;
 
 typedef struct _GLFWwndconfig   _GLFWwndconfig;
@@ -398,6 +401,7 @@ struct _GLFWwindow
 struct _GLFWmonitor
 {
     char*           name;
+    void*           userPointer;
 
     // Physical dimensions in millimeters.
     int             widthMM, heightMM;
@@ -921,6 +925,9 @@ void _glfwInputMonitorChange(void);
 /*! @ingroup event
  */
 void _glfwInputMonitorWindowChange(_GLFWmonitor* monitor, _GLFWwindow* window);
+
+void _glfwInputMonitor(_GLFWmonitor* monitor, int action, int placement);
+void _glfwInputMonitorWindow(_GLFWmonitor* monitor, _GLFWwindow* window);
 
 /*! @brief Notifies shared code of an error.
  *  @param[in] error The error code most suitable for the error.

--- a/v3.2/glfw/glfw/src/win32_init.c
+++ b/v3.2/glfw/glfw/src/win32_init.c
@@ -309,7 +309,7 @@ static HWND createHelperWindow(void)
                                   L"GLFW helper window",
                                   WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
                                   0, 0, 1, 1,
-                                  HWND_MESSAGE, NULL,
+                                  NULL, NULL,
                                   GetModuleHandleW(NULL),
                                   NULL);
     if (!window)
@@ -428,6 +428,7 @@ int _glfwPlatformInit(void)
     _glfwInitTimerWin32();
     _glfwInitJoysticksWin32();
 
+    _glfwPollMonitorsWin32();
     return GLFW_TRUE;
 }
 

--- a/v3.2/glfw/glfw/src/win32_platform.h
+++ b/v3.2/glfw/glfw/src/win32_platform.h
@@ -344,6 +344,7 @@ char* _glfwCreateUTF8FromWideStringWin32(const WCHAR* source);
 
 void _glfwInitTimerWin32(void);
 
+void _glfwPollMonitorsWin32(void);
 GLFWbool _glfwSetVideoModeWin32(_GLFWmonitor* monitor, const GLFWvidmode* desired);
 void _glfwRestoreVideoModeWin32(_GLFWmonitor* monitor);
 

--- a/v3.2/glfw/glfw/src/win32_platform.h
+++ b/v3.2/glfw/glfw/src/win32_platform.h
@@ -64,6 +64,9 @@
 // GLFW uses DirectInput8 interfaces
 #define DIRECTINPUT_VERSION 0x0800
 
+// Enable standard cursors images defines
+#define OEMRESOURCE
+
 #include <wctype.h>
 #include <windows.h>
 #include <mmsystem.h>

--- a/v3.2/glfw/glfw/src/win32_window.c
+++ b/v3.2/glfw/glfw/src/win32_window.c
@@ -405,7 +405,7 @@ static GLFWbool acquireMonitor(_GLFWwindow* window)
                  xpos, ypos, mode.width, mode.height,
                  SWP_NOACTIVATE | SWP_NOCOPYBITS);
 
-    _glfwInputMonitorWindowChange(window->monitor, window);
+    _glfwInputMonitorWindow(window->monitor, window);
     return status;
 }
 
@@ -416,7 +416,7 @@ static void releaseMonitor(_GLFWwindow* window)
     if (window->monitor->window != window)
         return;
 
-    _glfwInputMonitorWindowChange(window->monitor, NULL);
+    _glfwInputMonitorWindow(window->monitor, NULL);
     _glfwRestoreVideoModeWin32(window->monitor);
 }
 
@@ -432,14 +432,12 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
 
         switch (uMsg)
         {
+            case WM_DISPLAYCHANGE:
+                _glfwPollMonitorsWin32();
+                break;
             case WM_DEVICECHANGE:
             {
-                if (wParam == DBT_DEVNODES_CHANGED)
-                {
-                    _glfwInputMonitorChange();
-                    return TRUE;
-                }
-                else if (wParam == DBT_DEVICEARRIVAL)
+                if (wParam == DBT_DEVICEARRIVAL)
                 {
                     DEV_BROADCAST_HDR* dbh = (DEV_BROADCAST_HDR*) lParam;
                     if (dbh)

--- a/v3.2/glfw/glfw/src/win32_window.c
+++ b/v3.2/glfw/glfw/src/win32_window.c
@@ -280,25 +280,25 @@ static void updateClipRect(_GLFWwindow* window)
 
 // Translates a GLFW standard cursor to a resource ID
 //
-static LPWSTR translateCursorShape(int shape)
+static int translateCursorShape(int shape)
 {
     switch (shape)
     {
         case GLFW_ARROW_CURSOR:
-            return IDC_ARROW;
+            return OCR_NORMAL;
         case GLFW_IBEAM_CURSOR:
-            return IDC_IBEAM;
+            return OCR_IBEAM;
         case GLFW_CROSSHAIR_CURSOR:
-            return IDC_CROSS;
+            return OCR_CROSS;
         case GLFW_HAND_CURSOR:
-            return IDC_HAND;
+            return OCR_HAND;
         case GLFW_HRESIZE_CURSOR:
-            return IDC_SIZEWE;
+            return OCR_SIZEWE;
         case GLFW_VRESIZE_CURSOR:
-            return IDC_SIZENS;
+            return OCR_SIZENS;
     }
 
-    return NULL;
+    return 0;
 }
 
 // Retrieves and translates modifier keys
@@ -1523,7 +1523,8 @@ int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
 int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
 {
     cursor->win32.handle =
-        CopyCursor(LoadCursorW(NULL, translateCursorShape(shape)));
+        (HCURSOR)LoadImage(NULL, MAKEINTRESOURCE(translateCursorShape(shape)), IMAGE_CURSOR,
+                           0, 0, LR_DEFAULTSIZE | LR_SHARED);
     if (!cursor->win32.handle)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,


### PR DESCRIPTION
- Consolidates GLFW 3.3 source code into patch to resolve on Windows monitor change event is not get fired issue.
Incorporates changes from [glfw/glfw@97dbd8b](https://github.com/glfw/glfw/commit/97dbd8b63bbd15bb781e54a670b183dbd59f1bf0) and others GLFW 3.3 monitor info polling related changes.

- Dpi aware cursor icons on Windows.

Changelist resolves blocking issues to create monitor dpi aware ui on Windows.

https://github.com/go-gl/glfw/compare/master...MaxRis:windows-multihead-support-patch?expand=1#diff-ed2f694b139e131c7cca020fdb199d38R1526 that change will be suggested into GLFW 3.3 as PR
