### PR TITLE
Add GetProcAddress

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@
 
 Coşku Baş
 Dmitri Shuralyov
+Geert-Johan Riemer
 James Gray
 Peter Waller <p@pwaller.net> (github:pwaller)
 Robin Eklind

--- a/v3.0/glfw/context.go
+++ b/v3.0/glfw/context.go
@@ -70,3 +70,18 @@ func ExtensionSupported(extension string) bool {
 
 	return glfwbool(C.glfwExtensionSupported(e))
 }
+
+// GetProcAddress returns the address of the specified OpenGL or OpenGL ES core
+// or extension function, if it is supported by the current context.
+//
+// A context must be current on the calling thread. Calling this function
+// without a current context will cause a GLFW_NO_CURRENT_CONTEXT error.
+//
+// This function is used to provide GL proc resolving capabilities to an
+// external C library.
+func GetProcAddress(procname string) unsafe.Pointer {
+	p := C.CString(procname)
+	defer C.free(unsafe.Pointer(p))
+
+	return unsafe.Pointer(C.glfwGetProcAddress(p))
+}

--- a/v3.1/glfw/context.go
+++ b/v3.1/glfw/context.go
@@ -75,3 +75,19 @@ func ExtensionSupported(extension string) bool {
 	panicError()
 	return ret
 }
+
+// GetProcAddress returns the address of the specified OpenGL or OpenGL ES core
+// or extension function, if it is supported by the current context.
+//
+// A context must be current on the calling thread. Calling this function
+// without a current context will cause a GLFW_NO_CURRENT_CONTEXT error.
+//
+// This function is used to provide GL proc resolving capabilities to an
+// external C library.
+func GetProcAddress(procname string) unsafe.Pointer {
+	p := C.CString(procname)
+	defer C.free(unsafe.Pointer(p))
+	ret := unsafe.Pointer(C.glfwGetProcAddress(p))
+	panicError()
+	return ret
+}

--- a/v3.2/glfw/context.go
+++ b/v3.2/glfw/context.go
@@ -75,3 +75,19 @@ func ExtensionSupported(extension string) bool {
 	panicError()
 	return ret
 }
+
+// GetProcAddress returns the address of the specified OpenGL or OpenGL ES core
+// or extension function, if it is supported by the current context.
+//
+// A context must be current on the calling thread. Calling this function
+// without a current context will cause a GLFW_NO_CURRENT_CONTEXT error.
+//
+// This function is used to provide GL proc resolving capabilities to an
+// external C library.
+func GetProcAddress(procname string) unsafe.Pointer {
+	p := C.CString(procname)
+	defer C.free(unsafe.Pointer(p))
+	ret := unsafe.Pointer(C.glfwGetProcAddress(p))
+	panicError()
+	return ret
+}


### PR DESCRIPTION
This PR adds an exported Go function for the `glfwGetProcAddress` function.

Fixes #234 

Example usage at: https://github.com/Drakirus/go-flutter-desktop-embedder/compare/master...GeertJohan:feature/add-gl-proc-resolver-via-go-gl-glfw

Related issue at Drakirus/go-flutter-desktop-embedder: https://github.com/Drakirus/go-flutter-desktop-embedder/issues/68
