### PR TITLE
v3.2/glfw: gofmt

### DIFF
--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -316,7 +316,7 @@ func (w *Window) ShouldClose() bool {
 // should be closed.
 func (w *Window) SetShouldClose(value bool) {
 	if !value {
-		C.glfwSetWindowShouldClose(w.data, C.int(False)) 
+		C.glfwSetWindowShouldClose(w.data, C.int(False))
 	} else {
 		C.glfwSetWindowShouldClose(w.data, C.int(True))
 	}


### PR DESCRIPTION
The build is currently broken because one of the .go files wasn't `gofmt`ed. This change fixes that.

Done with:

	gofmt -w -s .

Using Go 1.12.3.