### PR TITLE
Add option to use external GLFW library

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,10 @@ Note that required packages might differ from those listed above; consult your h
 
 If your host system has GLFW library already compiled and installed,
 you can link against it, instead of compiling and statically linking the embedded one.
-You do this by defining the appropriate build tag, e.g.
+You do this by passing `-tags=glfw_external` flag to `go build/install`,
+when building your application.
 
-For `v3.2`:
-```
-go get -u -tags=glfw_external github.com/go-gl/glfw/v3.2/glfw
-```
-
-For `v3.1`:
-```
-go get -u -tags=glfw_external github.com/go-gl/glfw/v3.1/glfw
-```
-
-This tag does not take effect with `v3.0` bindings.
+Supported for `v3.1` and later.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note that required packages might differ from those listed above; consult your h
 
 If your host system has GLFW library already compiled and installed,
 you can link against it, instead of compiling and statically linking the embedded one.
-You do this by passing `-tags=glfw_external` flag to `go build/install`,
+You do this by passing `-tags=glfw_external` flag to `go build` or `go install`,
 when building your application.
 
 Supported for `v3.1` and later.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ go get -u -tags=gles2 github.com/go-gl/glfw/v3.2/glfw
 Supported tags are `gles1`, `gles2`, `gles3` and `vulkan`.
 Note that required packages might differ from those listed above; consult your hardware's documentation.
 
+### External GLFW library
+
+If your host system has GLFW library already compiled and installed,
+you can link against it, instead of compiling and statically linking the embedded one.
+You do this by defining the appropriate build tag, e.g.
+
+For `v3.2`:
+```
+go get -u -tags=glfw_external github.com/go-gl/glfw/v3.2/glfw
+```
+
+For `v3.1`:
+```
+go get -u -tags=glfw_external github.com/go-gl/glfw/v3.1/glfw
+```
+
+This tag does not take effect with `v3.0` bindings.
+
 ## Usage
 
 ```Go

--- a/v3.1/glfw/c_glfw_external.go
+++ b/v3.1/glfw/c_glfw_external.go
@@ -1,0 +1,9 @@
+// +build glfw_external
+
+package glfw
+
+/*
+#cgo CFLAGS: -DGO_GLFW_EXTERNAL
+#cgo LDFLAGS: -lglfw
+*/
+import "C"

--- a/v3.1/glfw/cocoainit_darwin.go
+++ b/v3.1/glfw/cocoainit_darwin.go
@@ -2,8 +2,10 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_COCOA
 	#include "glfw/src/cocoa_init.m"
+#endif
 #endif
 */
 import "C"

--- a/v3.1/glfw/cocoamonitor_darwin.go
+++ b/v3.1/glfw/cocoamonitor_darwin.go
@@ -2,8 +2,10 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_COCOA
 	#include "glfw/src/cocoa_monitor.m"
+#endif
 #endif
 */
 import "C"

--- a/v3.1/glfw/cocoawindow_darwin.go
+++ b/v3.1/glfw/cocoawindow_darwin.go
@@ -2,8 +2,10 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_COCOA
 	#include "glfw/src/cocoa_window.m"
+#endif
 #endif
 */
 import "C"

--- a/v3.1/glfw/context.go
+++ b/v3.1/glfw/context.go
@@ -1,8 +1,16 @@
 package glfw
 
-//#include <stdlib.h>
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#include <stdlib.h>
+
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+#else
+	#include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 import (

--- a/v3.1/glfw/error.go
+++ b/v3.1/glfw/error.go
@@ -1,8 +1,16 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//void glfwSetErrorCallbackCB();
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+#else
+	#include <GLFW/glfw3.h>
+#endif
+
+void glfwSetErrorCallbackCB();
+*/
 import "C"
 
 import (

--- a/v3.1/glfw/glfw.go
+++ b/v3.1/glfw/glfw.go
@@ -1,7 +1,14 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+#else
+	#include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 const (

--- a/v3.1/glfw/glfw_context.c
+++ b/v3.1/glfw/glfw_context.c
@@ -1,1 +1,3 @@
-#include "glfw/src/context.c"
+#ifndef GO_GLFW_EXTERNAL
+    #include "glfw/src/context.c"
+#endif

--- a/v3.1/glfw/glfw_egl_context.c
+++ b/v3.1/glfw/glfw_egl_context.c
@@ -1,4 +1,6 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_EGL
 	#include "glfw/src/egl_context.c"
+#endif
 #endif
 

--- a/v3.1/glfw/glfw_glx_context.c
+++ b/v3.1/glfw/glfw_glx_context.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_GLX
 	#include "glfw/src/glx_context.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_init.c
+++ b/v3.1/glfw/glfw_init.c
@@ -1,1 +1,3 @@
-#include "glfw/src/init.c"
+#ifndef GO_GLFW_EXTERNAL
+    #include "glfw/src/init.c"
+#endif

--- a/v3.1/glfw/glfw_input.c
+++ b/v3.1/glfw/glfw_input.c
@@ -1,2 +1,4 @@
-#include "glfw/src/input.c"
+#ifndef GO_GLFW_EXTERNAL
+    #include "glfw/src/input.c"
+#endif
 

--- a/v3.1/glfw/glfw_linux_joystick.c
+++ b/v3.1/glfw/glfw_linux_joystick.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #if defined(_GLFW_X11) || defined(_GLFW_WAYLAND)
 	#include "glfw/src/linux_joystick.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_mach_time.c
+++ b/v3.1/glfw/glfw_mach_time.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_COCOA
 	#include "glfw/src/mach_time.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_monitor.c
+++ b/v3.1/glfw/glfw_monitor.c
@@ -1,2 +1,3 @@
-#include "glfw/src/monitor.c"
-
+#ifndef GO_GLFW_EXTERNAL
+    #include "glfw/src/monitor.c"
+#endif

--- a/v3.1/glfw/glfw_posix_time.c
+++ b/v3.1/glfw/glfw_posix_time.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #if defined(_GLFW_X11) || defined(_GLFW_WAYLAND)
 	#include "glfw/src/posix_time.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_posix_tls.c
+++ b/v3.1/glfw/glfw_posix_tls.c
@@ -1,3 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #if defined(_GLFW_COCOA) || defined(_GLFW_X11) || defined(_GLFW_WAYLAND)
 	#include "glfw/src/posix_tls.c"
+#endif
 #endif

--- a/v3.1/glfw/glfw_wgl_context.c
+++ b/v3.1/glfw/glfw_wgl_context.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WGL
 	#include "glfw/src/wgl_context.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_win32_init.c
+++ b/v3.1/glfw/glfw_win32_init.c
@@ -12,7 +12,7 @@
 		return new;
 	}
 	#endif
-	
+
 	// _get_output_format is described at MSDN:
 	// http://msdn.microsoft.com/en-us/library/571yb472.aspx
 	//
@@ -24,6 +24,8 @@
 	};
 	#endif
 
-	#include "glfw/src/win32_init.c"
+	#ifndef GO_GLFW_EXTERNAL
+		#include "glfw/src/win32_init.c"
+	#endif
 #endif
 

--- a/v3.1/glfw/glfw_win32_monitor.c
+++ b/v3.1/glfw/glfw_win32_monitor.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WIN32
 	#include "glfw/src/win32_monitor.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_win32_time.c
+++ b/v3.1/glfw/glfw_win32_time.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WIN32
 	#include "glfw/src/win32_time.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_win32_tls.c
+++ b/v3.1/glfw/glfw_win32_tls.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WIN32
 	#include "glfw/src/win32_tls.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_win32_window.c
+++ b/v3.1/glfw/glfw_win32_window.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WIN32
 	#include "glfw/src/win32_window.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_window.c
+++ b/v3.1/glfw/glfw_window.c
@@ -1,1 +1,3 @@
-#include "glfw/src/window.c"
+#ifndef GO_GLFW_EXTERNAL
+    #include "glfw/src/window.c"
+#endif

--- a/v3.1/glfw/glfw_winmm_joystick.c
+++ b/v3.1/glfw/glfw_winmm_joystick.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WIN32
 	#include "glfw/src/winmm_joystick.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_wl_init.c
+++ b/v3.1/glfw/glfw_wl_init.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WAYLAND
 	#include "glfw/src/wl_init.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_wl_monitor.c
+++ b/v3.1/glfw/glfw_wl_monitor.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WAYLAND
 	#include "glfw/src/wl_monitor.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_wl_window.c
+++ b/v3.1/glfw/glfw_wl_window.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_WAYLAND
 	#include "glfw/src/wl_window.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_x11_init.c
+++ b/v3.1/glfw/glfw_x11_init.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_X11
 	#include "glfw/src/x11_init.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_x11_monitor.c
+++ b/v3.1/glfw/glfw_x11_monitor.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_X11
 	#include "glfw/src/x11_monitor.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_x11_window.c
+++ b/v3.1/glfw/glfw_x11_window.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_X11
 	#include "glfw/src/x11_window.c"
 #endif
-
+#endif

--- a/v3.1/glfw/glfw_xkb_unicode.c
+++ b/v3.1/glfw/glfw_xkb_unicode.c
@@ -1,4 +1,5 @@
+#ifndef GO_GLFW_EXTERNAL
 #if defined(_GLFW_X11) || defined(_GLFW_WAYLAND)
 	#include "glfw/src/xkb_unicode.c"
 #endif
-
+#endif

--- a/v3.1/glfw/input.go
+++ b/v3.1/glfw/input.go
@@ -1,17 +1,25 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//void glfwSetKeyCallbackCB(GLFWwindow *window);
-//void glfwSetCharCallbackCB(GLFWwindow *window);
-//void glfwSetCharModsCallbackCB(GLFWwindow *window);
-//void glfwSetMouseButtonCallbackCB(GLFWwindow *window);
-//void glfwSetCursorPosCallbackCB(GLFWwindow *window);
-//void glfwSetCursorEnterCallbackCB(GLFWwindow *window);
-//void glfwSetScrollCallbackCB(GLFWwindow *window);
-//void glfwSetDropCallbackCB(GLFWwindow *window);
-//float GetAxisAtIndex(float *axis, int i);
-//unsigned char GetButtonsAtIndex(unsigned char *buttons, int i);
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+#else
+	#include <GLFW/glfw3.h>
+#endif
+
+void glfwSetKeyCallbackCB(GLFWwindow *window);
+void glfwSetCharCallbackCB(GLFWwindow *window);
+void glfwSetCharModsCallbackCB(GLFWwindow *window);
+void glfwSetMouseButtonCallbackCB(GLFWwindow *window);
+void glfwSetCursorPosCallbackCB(GLFWwindow *window);
+void glfwSetCursorEnterCallbackCB(GLFWwindow *window);
+void glfwSetScrollCallbackCB(GLFWwindow *window);
+void glfwSetDropCallbackCB(GLFWwindow *window);
+float GetAxisAtIndex(float *axis, int i);
+unsigned char GetButtonsAtIndex(unsigned char *buttons, int i);
+*/
 import "C"
 
 import (

--- a/v3.1/glfw/iokitjoystick_darwin.go
+++ b/v3.1/glfw/iokitjoystick_darwin.go
@@ -2,8 +2,11 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_COCOA
 	#include "glfw/src/iokit_joystick.m"
+#endif
 #endif
 */
 import "C"

--- a/v3.1/glfw/monitor.go
+++ b/v3.1/glfw/monitor.go
@@ -1,12 +1,20 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//GLFWmonitor* GetMonitorAtIndex(GLFWmonitor **monitors, int index);
-//GLFWvidmode GetVidmodeAtIndex(GLFWvidmode *vidmodes, int index);
-//void glfwSetMonitorCallbackCB();
-//unsigned int GetGammaAtIndex(unsigned short *color, int i);
-//void SetGammaAtIndex(unsigned short *color, int i, unsigned short value);
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+#else
+	#include <GLFW/glfw3.h>
+#endif
+
+GLFWmonitor* GetMonitorAtIndex(GLFWmonitor **monitors, int index);
+GLFWvidmode GetVidmodeAtIndex(GLFWvidmode *vidmodes, int index);
+void glfwSetMonitorCallbackCB();
+unsigned int GetGammaAtIndex(unsigned short *color, int i);
+void SetGammaAtIndex(unsigned short *color, int i, unsigned short value);
+*/
 import "C"
 
 import (

--- a/v3.1/glfw/native_darwin.go
+++ b/v3.1/glfw/native_darwin.go
@@ -3,8 +3,14 @@ package glfw
 /*
 #define GLFW_EXPOSE_NATIVE_COCOA
 #define GLFW_EXPOSE_NATIVE_NSGL
-#include "glfw/include/GLFW/glfw3.h"
-#include "glfw/include/GLFW/glfw3native.h"
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+	#include "glfw/include/GLFW/glfw3native.h"
+#else
+	#include <GLFW/glfw3.h>
+	#include <GLFW/glfw3native.h>
+#endif
 
 // workaround wrappers needed due to a cgo and/or LLVM bug.
 // See: https://github.com/go-gl/glfw/issues/136

--- a/v3.1/glfw/native_linbsd.go
+++ b/v3.1/glfw/native_linbsd.go
@@ -2,11 +2,19 @@
 
 package glfw
 
-//#define GLFW_EXPOSE_NATIVE_X11
-//#define GLFW_EXPOSE_NATIVE_GLX
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//#include "glfw/include/GLFW/glfw3native.h"
+/*
+#define GLFW_EXPOSE_NATIVE_X11
+#define GLFW_EXPOSE_NATIVE_GLX
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+	#include "glfw/include/GLFW/glfw3native.h"
+#else
+	#include <GLFW/glfw3.h>
+	#include <GLFW/glfw3native.h>
+#endif
+*/
 import "C"
 
 func (w *Window) GetX11Window() C.Window {

--- a/v3.1/glfw/native_windows.go
+++ b/v3.1/glfw/native_windows.go
@@ -1,10 +1,18 @@
 package glfw
 
-//#define GLFW_EXPOSE_NATIVE_WIN32
-//#define GLFW_EXPOSE_NATIVE_WGL
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//#include "glfw/include/GLFW/glfw3native.h"
+/*
+#define GLFW_EXPOSE_NATIVE_WIN32
+#define GLFW_EXPOSE_NATIVE_WGL
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+	#include "glfw/include/GLFW/glfw3native.h"
+#else
+	#include <GLFW/glfw3.h>
+	#include <GLFW/glfw3native.h>
+#endif
+*/
 import "C"
 
 func (w *Window) GetWin32Window() C.HWND {

--- a/v3.1/glfw/nsglcontext_darwin.go
+++ b/v3.1/glfw/nsglcontext_darwin.go
@@ -2,8 +2,10 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#ifndef GO_GLFW_EXTERNAL
 #ifdef _GLFW_NSGL
 	#include "glfw/src/nsgl_context.m"
+#endif
 #endif
 */
 import "C"

--- a/v3.1/glfw/time.go
+++ b/v3.1/glfw/time.go
@@ -1,7 +1,14 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+#else
+	#include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 // GetTime returns the value of the GLFW timer. Unless the timer has been set

--- a/v3.1/glfw/util.go
+++ b/v3.1/glfw/util.go
@@ -1,8 +1,16 @@
 package glfw
 
-//#include <stdlib.h>
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#include <stdlib.h>
+
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+#else
+	#include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 import (

--- a/v3.1/glfw/window.go
+++ b/v3.1/glfw/window.go
@@ -1,15 +1,24 @@
 package glfw
 
-//#include <stdlib.h>
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//void glfwSetWindowPosCallbackCB(GLFWwindow *window);
-//void glfwSetWindowSizeCallbackCB(GLFWwindow *window);
-//void glfwSetFramebufferSizeCallbackCB(GLFWwindow *window);
-//void glfwSetWindowCloseCallbackCB(GLFWwindow *window);
-//void glfwSetWindowRefreshCallbackCB(GLFWwindow *window);
-//void glfwSetWindowFocusCallbackCB(GLFWwindow *window);
-//void glfwSetWindowIconifyCallbackCB(GLFWwindow *window);
+/*
+#include <stdlib.h>
+
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+	#include "glfw/include/GLFW/glfw3.h"
+#else
+	#include <GLFW/glfw3.h>
+#endif
+
+void glfwSetWindowPosCallbackCB(GLFWwindow *window);
+void glfwSetWindowSizeCallbackCB(GLFWwindow *window);
+void glfwSetFramebufferSizeCallbackCB(GLFWwindow *window);
+void glfwSetWindowCloseCallbackCB(GLFWwindow *window);
+void glfwSetWindowRefreshCallbackCB(GLFWwindow *window);
+void glfwSetWindowFocusCallbackCB(GLFWwindow *window);
+void glfwSetWindowIconifyCallbackCB(GLFWwindow *window);
+*/
 import "C"
 
 import (

--- a/v3.2/glfw/c_glfw.go
+++ b/v3.2/glfw/c_glfw.go
@@ -1,3 +1,5 @@
+// +build !glfw_external
+
 package glfw
 
 /*

--- a/v3.2/glfw/c_glfw_darwin.go
+++ b/v3.2/glfw/c_glfw_darwin.go
@@ -1,3 +1,5 @@
+// +build !glfw_external
+
 package glfw
 
 /*

--- a/v3.2/glfw/c_glfw_external.go
+++ b/v3.2/glfw/c_glfw_external.go
@@ -1,0 +1,9 @@
+// +build glfw_external
+
+package glfw
+
+/*
+#cgo CFLAGS: -DGO_GLFW_EXTERNAL
+#cgo LDFLAGS: -lglfw
+*/
+import "C"

--- a/v3.2/glfw/c_glfw_linbsd.go
+++ b/v3.2/glfw/c_glfw_linbsd.go
@@ -1,3 +1,4 @@
+// +build !glfw_external
 // +build linux freebsd
 
 package glfw

--- a/v3.2/glfw/c_glfw_windows.go
+++ b/v3.2/glfw/c_glfw_windows.go
@@ -1,3 +1,5 @@
+// +build !glfw_external
+
 package glfw
 
 /*

--- a/v3.2/glfw/context.go
+++ b/v3.2/glfw/context.go
@@ -1,8 +1,16 @@
 package glfw
 
-//#include <stdlib.h>
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#include <stdlib.h>
+
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 import (

--- a/v3.2/glfw/error.go
+++ b/v3.2/glfw/error.go
@@ -1,8 +1,16 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//void glfwSetErrorCallbackCB();
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+
+void glfwSetErrorCallbackCB();
+*/
 import "C"
 
 import (

--- a/v3.2/glfw/glfw.go
+++ b/v3.2/glfw/glfw.go
@@ -1,7 +1,14 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 // Version constants.

--- a/v3.2/glfw/input.go
+++ b/v3.2/glfw/input.go
@@ -1,18 +1,26 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//void glfwSetJoystickCallbackCB();
-//void glfwSetKeyCallbackCB(GLFWwindow *window);
-//void glfwSetCharCallbackCB(GLFWwindow *window);
-//void glfwSetCharModsCallbackCB(GLFWwindow *window);
-//void glfwSetMouseButtonCallbackCB(GLFWwindow *window);
-//void glfwSetCursorPosCallbackCB(GLFWwindow *window);
-//void glfwSetCursorEnterCallbackCB(GLFWwindow *window);
-//void glfwSetScrollCallbackCB(GLFWwindow *window);
-//void glfwSetDropCallbackCB(GLFWwindow *window);
-//float GetAxisAtIndex(float *axis, int i);
-//unsigned char GetButtonsAtIndex(unsigned char *buttons, int i);
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+
+void glfwSetJoystickCallbackCB();
+void glfwSetKeyCallbackCB(GLFWwindow *window);
+void glfwSetCharCallbackCB(GLFWwindow *window);
+void glfwSetCharModsCallbackCB(GLFWwindow *window);
+void glfwSetMouseButtonCallbackCB(GLFWwindow *window);
+void glfwSetCursorPosCallbackCB(GLFWwindow *window);
+void glfwSetCursorEnterCallbackCB(GLFWwindow *window);
+void glfwSetScrollCallbackCB(GLFWwindow *window);
+void glfwSetDropCallbackCB(GLFWwindow *window);
+float GetAxisAtIndex(float *axis, int i);
+unsigned char GetButtonsAtIndex(unsigned char *buttons, int i);
+*/
 import "C"
 
 import (

--- a/v3.2/glfw/monitor.go
+++ b/v3.2/glfw/monitor.go
@@ -1,12 +1,20 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//GLFWmonitor* GetMonitorAtIndex(GLFWmonitor **monitors, int index);
-//GLFWvidmode GetVidmodeAtIndex(GLFWvidmode *vidmodes, int index);
-//void glfwSetMonitorCallbackCB();
-//unsigned int GetGammaAtIndex(unsigned short *color, int i);
-//void SetGammaAtIndex(unsigned short *color, int i, unsigned short value);
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+
+GLFWmonitor* GetMonitorAtIndex(GLFWmonitor **monitors, int index);
+GLFWvidmode GetVidmodeAtIndex(GLFWvidmode *vidmodes, int index);
+void glfwSetMonitorCallbackCB();
+unsigned int GetGammaAtIndex(unsigned short *color, int i);
+void SetGammaAtIndex(unsigned short *color, int i, unsigned short value);
+*/
 import "C"
 
 import (

--- a/v3.2/glfw/native_darwin.go
+++ b/v3.2/glfw/native_darwin.go
@@ -3,8 +3,14 @@ package glfw
 /*
 #define GLFW_EXPOSE_NATIVE_COCOA
 #define GLFW_EXPOSE_NATIVE_NSGL
-#include "glfw/include/GLFW/glfw3.h"
-#include "glfw/include/GLFW/glfw3native.h"
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+  #include "glfw/include/GLFW/glfw3native.h"
+#else
+  #include <GLFW/glfw3.h>
+  #include <GLFW/glfw3native.h>
+#endif
 
 // workaround wrappers needed due to a cgo and/or LLVM bug.
 // See: https://github.com/go-gl/glfw/issues/136

--- a/v3.2/glfw/native_linbsd.go
+++ b/v3.2/glfw/native_linbsd.go
@@ -2,11 +2,19 @@
 
 package glfw
 
-//#define GLFW_EXPOSE_NATIVE_X11
-//#define GLFW_EXPOSE_NATIVE_GLX
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//#include "glfw/include/GLFW/glfw3native.h"
+/*
+#define GLFW_EXPOSE_NATIVE_X11
+#define GLFW_EXPOSE_NATIVE_GLX
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+  #include "glfw/include/GLFW/glfw3native.h"
+#else
+  #include <GLFW/glfw3.h>
+  #include <GLFW/glfw3native.h>
+#endif
+*/
 import "C"
 
 func GetX11Display() *C.Display {

--- a/v3.2/glfw/native_windows.go
+++ b/v3.2/glfw/native_windows.go
@@ -1,10 +1,18 @@
 package glfw
 
-//#define GLFW_EXPOSE_NATIVE_WIN32
-//#define GLFW_EXPOSE_NATIVE_WGL
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//#include "glfw/include/GLFW/glfw3native.h"
+/*
+#define GLFW_EXPOSE_NATIVE_WIN32
+#define GLFW_EXPOSE_NATIVE_WGL
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+  #include "glfw/include/GLFW/glfw3native.h"
+#else
+  #include <GLFW/glfw3.h>
+  #include <GLFW/glfw3native.h>
+#endif
+*/
 import "C"
 
 // GetWin32Adapter returns the adapter device name of the monitor.

--- a/v3.2/glfw/time.go
+++ b/v3.2/glfw/time.go
@@ -1,7 +1,14 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 // GetTime returns the value of the GLFW timer. Unless the timer has been set

--- a/v3.2/glfw/util.go
+++ b/v3.2/glfw/util.go
@@ -1,8 +1,16 @@
 package glfw
 
-//#include <stdlib.h>
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#include <stdlib.h>
+
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 import (

--- a/v3.2/glfw/vulkan.go
+++ b/v3.2/glfw/vulkan.go
@@ -1,7 +1,14 @@
 package glfw
 
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
+/*
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+*/
 import "C"
 
 // VulkanSupported reports whether the Vulkan loader has been found. This check is performed by Init.

--- a/v3.2/glfw/window.go
+++ b/v3.2/glfw/window.go
@@ -1,15 +1,24 @@
 package glfw
 
-//#include <stdlib.h>
-//#define GLFW_INCLUDE_NONE
-//#include "glfw/include/GLFW/glfw3.h"
-//void glfwSetWindowPosCallbackCB(GLFWwindow *window);
-//void glfwSetWindowSizeCallbackCB(GLFWwindow *window);
-//void glfwSetFramebufferSizeCallbackCB(GLFWwindow *window);
-//void glfwSetWindowCloseCallbackCB(GLFWwindow *window);
-//void glfwSetWindowRefreshCallbackCB(GLFWwindow *window);
-//void glfwSetWindowFocusCallbackCB(GLFWwindow *window);
-//void glfwSetWindowIconifyCallbackCB(GLFWwindow *window);
+/*
+#include <stdlib.h>
+
+#define GLFW_INCLUDE_NONE
+
+#ifndef GO_GLFW_EXTERNAL
+  #include "glfw/include/GLFW/glfw3.h"
+#else
+  #include <GLFW/glfw3.h>
+#endif
+
+void glfwSetWindowPosCallbackCB(GLFWwindow *window);
+void glfwSetWindowSizeCallbackCB(GLFWwindow *window);
+void glfwSetFramebufferSizeCallbackCB(GLFWwindow *window);
+void glfwSetWindowCloseCallbackCB(GLFWwindow *window);
+void glfwSetWindowRefreshCallbackCB(GLFWwindow *window);
+void glfwSetWindowFocusCallbackCB(GLFWwindow *window);
+void glfwSetWindowIconifyCallbackCB(GLFWwindow *window);
+*/
 import "C"
 
 import (


### PR DESCRIPTION
Closes: #246 

This commit adds an option to link against external GLFW library.
I think it would be convenient to also test this with CI.
I tested it only on linux, as I don't have access to machine with windows or darwin.

Simply appending `glfw_external` to `-tags` flag does the trick.

@tapir I didn't use `glfw-external` because it wasn't working, had to change `-` to `_`.