### PR TITLE
Add dummy.go to glfw source directory

### DIFF
--- a/v3.1/glfw/glfw/deps/EGL/dummy.go
+++ b/v3.1/glfw/glfw/deps/EGL/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.1/glfw/glfw/deps/EGL/dummy.go
+++ b/v3.1/glfw/glfw/deps/EGL/dummy.go
@@ -1,4 +1,4 @@
-//+build ignore
+// +build ignore
 
 package dummy
 

--- a/v3.1/glfw/glfw/deps/GL/dummy.go
+++ b/v3.1/glfw/glfw/deps/GL/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.1/glfw/glfw/deps/KHR/dummy.go
+++ b/v3.1/glfw/glfw/deps/KHR/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.1/glfw/glfw/deps/dummy.go
+++ b/v3.1/glfw/glfw/deps/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.1/glfw/glfw/deps/glad/dummy.go
+++ b/v3.1/glfw/glfw/deps/glad/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.1/glfw/glfw/include/GLFW/dummy.go
+++ b/v3.1/glfw/glfw/include/GLFW/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.1/glfw/glfw/include/dummy.go
+++ b/v3.1/glfw/glfw/include/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.1/glfw/glfw/src/dummy.go
+++ b/v3.1/glfw/glfw/src/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.2/glfw/glfw/deps/KHR/dummy.go
+++ b/v3.2/glfw/glfw/deps/KHR/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.2/glfw/glfw/deps/dummy.go
+++ b/v3.2/glfw/glfw/deps/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.2/glfw/glfw/deps/glad/dummy.go
+++ b/v3.2/glfw/glfw/deps/glad/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.2/glfw/glfw/deps/mingw/dummy.go
+++ b/v3.2/glfw/glfw/deps/mingw/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.2/glfw/glfw/deps/vulkan/dummy.go
+++ b/v3.2/glfw/glfw/deps/vulkan/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.2/glfw/glfw/include/GLFW/dummy.go
+++ b/v3.2/glfw/glfw/include/GLFW/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.2/glfw/glfw/include/dummy.go
+++ b/v3.2/glfw/glfw/include/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.2/glfw/glfw/src/dummy.go
+++ b/v3.2/glfw/glfw/src/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.3/glfw/glfw/deps/dummy.go
+++ b/v3.3/glfw/glfw/deps/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.3/glfw/glfw/deps/glad/dummy.go
+++ b/v3.3/glfw/glfw/deps/glad/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.3/glfw/glfw/deps/mingw/dummy.go
+++ b/v3.3/glfw/glfw/deps/mingw/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.3/glfw/glfw/deps/vs2008/dummy.go
+++ b/v3.3/glfw/glfw/deps/vs2008/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.3/glfw/glfw/include/GLFW/dummy.go
+++ b/v3.3/glfw/glfw/include/GLFW/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.3/glfw/glfw/include/dummy.go
+++ b/v3.3/glfw/glfw/include/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251

--- a/v3.3/glfw/glfw/src/dummy.go
+++ b/v3.3/glfw/glfw/src/dummy.go
@@ -1,0 +1,5 @@
+//+build ignore
+
+package dummy
+
+// This package exists to support go mod vendor. See #251


### PR DESCRIPTION
Implemented with this shell fragment:

```
for x in $(find */*/glfw/* -type d); do
  echo $'package dummy\n// This package exists to support 'go mod vendor'. See #251' > $x/dummy.go
  git add $x/dummy.go
done
```

Fix #251.