### PR TITLE
.travis.yml: use latest stable Go (1.13.8 and 1.12.17 at this time)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,17 @@ addons:
     - xorg-dev
 language: go
 go:
-  - 1.11.x
-  - 1.10.x
-  - tip
+  - 1.x
+  - 1.12.x
+  - master
 matrix:
   allow_failures:
-    - go: tip
+    - go: master
   fast_finish: true
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
-  - go get -t -v ./v3.3/...
-  - diff -u <(echo -n) <(gofmt -d -s .)
-  - go tool vet .
-  - go test -v -race ./v3.3/...
+  - go get -t -v ./v3.3/... ./v3.2/...
+  - diff -n <(echo -n) <(gofmt -d -s .)
+  - go vet ./v3.3/... ./v3.2/...
+  - go test -v -race ./v3.3/... ./v3.2/...


### PR DESCRIPTION
Go 1.11.x and 1.10.x are very old by now; update to current versions.

Also resume testing v3.2/glfw package. It will be supported until it becomes too hard to support, then we'll say "please use v3.3 or newer".

As of Go 1.12, go tool vet is no longer supported.¹ Start using the go vet command instead.

Use RCS format for gofmt diff. It results in cleaner, easier to read gofmt diffs.

¹ https://golang.org/doc/go1.12#vet