### PR TITLE
fix: go mod vendor

### DIFF
--- a/v3.3/glfw/build_cgo_hack.go
+++ b/v3.3/glfw/build_cgo_hack.go
@@ -10,7 +10,7 @@ package glfw
 //  - every directory we want to preserve is included here as a _ import.
 //  - this file is given a build to exclude it from the regular build.
 import (
-	// prevent go tooling from stripping out the c source files.
+	// Prevent go tooling from stripping out the c source files.
 	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/deps"
 	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/include/GLFW"
 	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/src"

--- a/v3.3/glfw/build_cgo_hack.go
+++ b/v3.3/glfw/build_cgo_hack.go
@@ -1,0 +1,17 @@
+// +build required
+
+package glfw
+
+// this file exists purely to prevent the golang toolchain from stripping
+// away the c source directories and files.
+//
+// how it works:
+//  - every directory which only includes c source files receives a dummy.go file.
+//  - every directory we want to preserve is included here as a _ import.
+//  - this file is given a build to exclude it from the regular build.
+import (
+	// prevent go tooling from stripping out the c source files.
+	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/deps"
+	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/include/GLFW"
+	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/src"
+)

--- a/v3.3/glfw/build_cgo_hack.go
+++ b/v3.3/glfw/build_cgo_hack.go
@@ -2,8 +2,9 @@
 
 package glfw
 
-// this file exists purely to prevent the golang toolchain from stripping
-// away the c source directories and files.
+// This file exists purely to prevent the golang toolchain from stripping
+// away the c source directories and files when `go mod vendor` is used
+// to populate a `vendor/` directory of a project depending on `go-gl/glfw`.
 //
 // How it works:
 //  - every directory which only includes c source files receives a dummy.go file.

--- a/v3.3/glfw/build_cgo_hack.go
+++ b/v3.3/glfw/build_cgo_hack.go
@@ -5,7 +5,7 @@ package glfw
 // this file exists purely to prevent the golang toolchain from stripping
 // away the c source directories and files.
 //
-// how it works:
+// How it works:
 //  - every directory which only includes c source files receives a dummy.go file.
 //  - every directory we want to preserve is included here as a _ import.
 //  - this file is given a build to exclude it from the regular build.

--- a/v3.3/glfw/glfw/deps/dummy.go
+++ b/v3.3/glfw/glfw/deps/dummy.go
@@ -4,7 +4,7 @@
 package dummy
 
 import (
-	// prevent go tooling from stripping out the c source files.
+	// Prevent go tooling from stripping out the c source files.
 	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/deps/glad"
 	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/deps/mingw"
 	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/deps/vs2008"

--- a/v3.3/glfw/glfw/deps/dummy.go
+++ b/v3.3/glfw/glfw/deps/dummy.go
@@ -1,0 +1,11 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy
+
+import (
+	// prevent go tooling from stripping out the c source files.
+	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/deps/glad"
+	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/deps/mingw"
+	_ "github.com/go-gl/glfw/v3.3/glfw/glfw/deps/vs2008"
+)

--- a/v3.3/glfw/glfw/deps/glad/dummy.go
+++ b/v3.3/glfw/glfw/deps/glad/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/v3.3/glfw/glfw/deps/mingw/dummy.go
+++ b/v3.3/glfw/glfw/deps/mingw/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/v3.3/glfw/glfw/deps/vs2008/dummy.go
+++ b/v3.3/glfw/glfw/deps/vs2008/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/v3.3/glfw/glfw/include/GLFW/dummy.go
+++ b/v3.3/glfw/glfw/include/GLFW/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/v3.3/glfw/glfw/src/dummy.go
+++ b/v3.3/glfw/glfw/src/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy


### PR DESCRIPTION
fixes #251 

add dummy files to ensure c source is maintained transparently.

why this works vs #258 because // +build ignore is treated specially by golangs toolchain and its necessary to import the packages for them to be maintained.

I'm only doing this for v3.3 because that is all I require for my use case atm. Someone else can pick up the other versions if/when necessary.