### PR TITLE
fix regression from #256 "`GetClipboardString` No longer returns an e…

### DIFF
--- a/v3.3/glfw/glfw.go
+++ b/v3.3/glfw/glfw.go
@@ -100,6 +100,7 @@ func GetVersionString() string {
 func GetClipboardString() string {
 	cs := C.glfwGetClipboardString(nil)
 	if cs == nil {
+		acceptError(FormatUnavailable)
 		return ""
 	}
 	return C.GoString(cs)

--- a/v3.3/glfw/window.go
+++ b/v3.3/glfw/window.go
@@ -930,6 +930,7 @@ func (w *Window) SetClipboardString(str string) {
 func (w *Window) GetClipboardString() string {
 	cs := C.glfwGetClipboardString(w.data)
 	if cs == nil {
+		acceptError(FormatUnavailable)
 		return ""
 	}
 	return C.GoString(cs)


### PR DESCRIPTION
…rror."

This changes was first introduced in https://github.com/go-gl/glfw/blob/6e2aad9c205df8e65253545488dd5012bce36960/v3.3/glfw/window.go#L1072-L1082
Where errors where handled differently.
On #256, we forgot to revert the change.

This fixes #276 without changing the API.
Multiple project encountered this bug:
* https://github.com/fyne-io/fyne/issues/743
* https://github.com/go-flutter-desktop/go-flutter/issues/393