### PR TITLE
Fixes a compiler error by using null joystick on freebsd

### DIFF
--- a/v3.3/glfw/c_glfw_freebsd.go
+++ b/v3.3/glfw/c_glfw_freebsd.go
@@ -1,4 +1,4 @@
-// +build linux freebsd
+// +build freebsd
 
 package glfw
 
@@ -15,7 +15,7 @@ package glfw
 	#include "glfw/src/x11_window.c"
 	#include "glfw/src/glx_context.c"
 #endif
-#include "glfw/src/linux_joystick.c"
+#include "glfw/src/null_joystick.c"
 #include "glfw/src/posix_time.c"
 #include "glfw/src/posix_thread.c"
 #include "glfw/src/xkb_unicode.c"

--- a/v3.3/glfw/c_glfw_lin.go
+++ b/v3.3/glfw/c_glfw_lin.go
@@ -1,0 +1,24 @@
+// +build linux
+
+package glfw
+
+/*
+#ifdef _GLFW_WAYLAND
+	#include "glfw/src/wl_init.c"
+	#include "glfw/src/wl_monitor.c"
+	#include "glfw/src/wl_window.c"
+	#include "glfw/src/wl_platform.h"
+#endif
+#ifdef _GLFW_X11
+	#include "glfw/src/x11_init.c"
+	#include "glfw/src/x11_monitor.c"
+	#include "glfw/src/x11_window.c"
+	#include "glfw/src/glx_context.c"
+#endif
+#include "glfw/src/linux_joystick.c"
+#include "glfw/src/posix_time.c"
+#include "glfw/src/posix_thread.c"
+#include "glfw/src/xkb_unicode.c"
+#include "glfw/src/egl_context.c"
+*/
+import "C"


### PR DESCRIPTION
Created a separate c file for freebsd and updated the joystick ref to use the null joystick.

Built, compiled and ran OpenDiablo which is where this issue was discovered. https://github.com/go-gl/glfw/issues/264#issuecomment-647238581

@pwaller 
