### PR TITLE
add gles2 tag to support using gles2 on windows

### DIFF
--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -7,8 +7,10 @@ package glfw
 #cgo windows CFLAGS: -D_GLFW_WIN32 -Iglfw/deps/mingw
 
 // Linker Options:
-#cgo windows LDFLAGS: -lopengl32 -lgdi32
+#cgo windows LDFLAGS: -lgdi32
 
+#cgo !gles2,windows LDFLAGS: -lopengl32
+#cgo gles2,windows LDFLAGS: -lGLESv2
 
 // Darwin Build Tags
 // ----------------


### PR DESCRIPTION
default option is still using desktop OpenGL