### PR TITLE
Use C.CBytes() to implement bytes(), fix vet warning

### DIFF
--- a/v3.2/glfw/util.go
+++ b/v3.2/glfw/util.go
@@ -5,11 +5,6 @@ package glfw
 //#include "glfw/include/GLFW/glfw3.h"
 import "C"
 
-import (
-	"reflect"
-	"unsafe"
-)
-
 func glfwbool(b C.int) bool {
 	if b == C.int(True) {
 		return true
@@ -19,20 +14,10 @@ func glfwbool(b C.int) bool {
 
 func bytes(origin []byte) (pointer *uint8, free func()) {
 	n := len(origin)
-
 	if n == 0 {
 		return nil, func() {}
 	}
 
-	data := C.malloc(C.size_t(n))
-
-	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(data),
-		Len:  n,
-		Cap:  n,
-	}))
-
-	copy(dataSlice, origin)
-
-	return &dataSlice[0], func() { C.free(data) }
+	ptr := C.CBytes(origin)
+	return (*uint8)(ptr), func() { C.free(ptr) }
 }

--- a/v3.3/glfw/util.go
+++ b/v3.3/glfw/util.go
@@ -5,11 +5,6 @@ package glfw
 //#include "glfw/include/GLFW/glfw3.h"
 import "C"
 
-import (
-	"reflect"
-	"unsafe"
-)
-
 func glfwbool(b C.int) bool {
 	if b == C.int(True) {
 		return true
@@ -19,20 +14,10 @@ func glfwbool(b C.int) bool {
 
 func bytes(origin []byte) (pointer *uint8, free func()) {
 	n := len(origin)
-
 	if n == 0 {
 		return nil, func() {}
 	}
 
-	data := C.malloc(C.size_t(n))
-
-	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(data),
-		Len:  n,
-		Cap:  n,
-	}))
-
-	copy(dataSlice, origin)
-
-	return &dataSlice[0], func() { C.free(data) }
+	ptr := C.CBytes(origin)
+	return (*uint8)(ptr), func() { C.free(ptr) }
 }


### PR DESCRIPTION
CI is currently failing with the following on go1.16:

```
v3.2/glfw/util.go:29:41: possible misuse of reflect.SliceHeader
v3.3/glfw/util.go:29:41: possible misuse of reflect.SliceHeader
```

I don't know whether this is a false positive or not but we should try to be go-vet clean.

It looks to me like `bytes()` could be implemented with this instead, avoiding the issue altogether:

```
func C.CBytes([]byte) unsafe.Pointer
```

At this point, I've only built, but not tested this behaviour extensively, to get CI passing. It looks low risk but don't know if there is anything subtly different about the original implementation. @tapir any thoughts?