### PR TITLE
Specify ubuntu 20.04 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: focal
 addons:
   apt_packages:
     - libgl1-mesa-dev


### PR DESCRIPTION
Choosing this because we need to choose some version to get consistent wayland
sources in #271.