### PR TITLE
Ignore invalidValue at PollEvents, WaitEvents, and WaitEventsTimeout

### DIFF
--- a/v3.3/glfw/window.go
+++ b/v3.3/glfw/window.go
@@ -936,6 +936,21 @@ func (w *Window) GetClipboardString() string {
 	return C.GoString(cs)
 }
 
+// panicErrorExceptForInvalidValue is the same as panicError but ignores
+// invalidValue.
+func panicErrorExceptForInvalidValue() {
+	// invalidValue can happen when specific joysticks are used. This issue
+	// will be fixed in GLFW 3.3.5. As a temporary fix, ignore this error.
+	// See go-gl/glfw#292, go-gl/glfw#324, and glfw/glfw#1763.
+	err := acceptError(invalidValue)
+	if e, ok := err.(*Error); ok && e.Code == invalidValue {
+		return
+	}
+	if err != nil {
+		panic(err)
+	}
+}
+
 // PollEvents processes only those events that have already been received and
 // then returns immediately. Processing events will cause the window and input
 // callbacks associated with those events to be called.
@@ -947,7 +962,7 @@ func (w *Window) GetClipboardString() string {
 // This function may only be called from the main thread.
 func PollEvents() {
 	C.glfwPollEvents()
-	panicError()
+	panicErrorExceptForInvalidValue()
 }
 
 // WaitEvents puts the calling thread to sleep until at least one event has been
@@ -965,7 +980,7 @@ func PollEvents() {
 // This function may only be called from the main thread.
 func WaitEvents() {
 	C.glfwWaitEvents()
-	panicError()
+	panicErrorExceptForInvalidValue()
 }
 
 // WaitEventsTimeout puts the calling thread to sleep until at least one event is available in the
@@ -992,7 +1007,7 @@ func WaitEvents() {
 // Event processing is not required for joystick input to work.
 func WaitEventsTimeout(timeout float64) {
 	C.glfwWaitEventsTimeout(C.double(timeout))
-	panicError()
+	panicErrorExceptForInvalidValue()
 }
 
 // PostEmptyEvent posts an empty event from the current thread to the main


### PR DESCRIPTION
This error happens when a joystick is connected while the application
is running.

Updates #324
Updates #292