### PR TITLE
v3.3/glfw: update to GLFW 3.3.4

### DIFF
--- a/v3.3/glfw/GLFW_C_REVISION.txt
+++ b/v3.3/glfw/GLFW_C_REVISION.txt
@@ -1,1 +1,1 @@
-746cdea490a70dd6747272a171b19e5ec1fb9900
+b3e0aae393ef6c5cda7dcad0cba06bef23a1dda9

--- a/v3.3/glfw/glfw/include/GLFW/glfw3.h
+++ b/v3.3/glfw/glfw/include/GLFW/glfw3.h
@@ -295,7 +295,7 @@ extern "C" {
  *  API changes.
  *  @ingroup init
  */
-#define GLFW_VERSION_REVISION       3
+#define GLFW_VERSION_REVISION       4
 /*! @} */
 
 /*! @brief One.

--- a/v3.3/glfw/glfw/src/win32_init.c
+++ b/v3.3/glfw/glfw/src/win32_init.c
@@ -39,6 +39,10 @@ static const GUID _glfw_GUID_DEVINTERFACE_HID =
 
 #if defined(_GLFW_USE_HYBRID_HPG) || defined(_GLFW_USE_OPTIMUS_HPG)
 
+#if defined(_GLFW_BUILD_DLL)
+ #warning "These symbols must be exported by the executable and have no effect in a DLL"
+#endif
+
 // Executables (but not DLLs) exporting this symbol with this value will be
 // automatically directed to the high-performance GPU on Nvidia Optimus systems
 // with up-to-date drivers

--- a/v3.3/glfw/glfw/src/x11_window.c
+++ b/v3.3/glfw/glfw/src/x11_window.c
@@ -2500,7 +2500,11 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
     }
 
     if (window->monitor)
+    {
+        _glfwPlatformSetWindowDecorated(window, window->decorated);
+        _glfwPlatformSetWindowFloating(window, window->floating);
         releaseMonitor(window);
+    }
 
     _glfwInputWindowMonitor(window, monitor);
     updateNormalHints(window, width, height);

--- a/v3.3/glfw/glfw_tree_rebuild.go
+++ b/v3.3/glfw/glfw_tree_rebuild.go
@@ -7,4 +7,4 @@ package glfw
 // generate` on this package. This exists to invalidate the build cache (see
 // https://github.com/go-gl/glfw/issues/269), which is unaffected by C source
 // inputs.
-const upstreamTreeSHA = "35599f5c137b48f8395629e686000729426bf966"
+const upstreamTreeSHA = "0d55f6838e16265b6ed4a10bec69d1f07e57ae39"


### PR DESCRIPTION
GLFW 3.3.4 was released on April 8, 2021.
See https://github.com/glfw/glfw/releases/tag/3.3.4.

Done with scripts/grab-upstream.sh (albeit with edits):

	echo 'b3e0aae393ef6c5cda7dcad0cba06bef23a1dda9' > v3.3/glfw/GLFW_C_REVISION.txt  # 3.3.4.
	./scripts/grab-upstream.sh

The grab-upstream.sh script was modified to comment out Wayland
regeneration and invocations of sed, as it didn't work on macOS
out of the box. (I didn't think it'd be worth it given the diff
of 3.3.3 → 3.3.4 being so small.)

Fixes #328.