### PR TITLE
v3.3/glfw: add netbsd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 	* On Ubuntu/Debian-like Linux distributions, you need `libgl1-mesa-dev` and `xorg-dev` packages.
 	* On CentOS/Fedora-like Linux distributions, you need `libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel mesa-libGL-devel libXi-devel libXxf86vm-devel` packages.
 	* On FreeBSD, you need the package `pkgconf`. To build for X, you also need the package `xorg`; and to build for Wayland, you need the package `wayland`.
+	* On NetBSD, to build for X, you need the X11 sets installed. These are included in all graphical installs, and can be added to the system with `sysinst(8)` on non-graphical systems. Wayland support is incomplete, due to missing wscons support in upstream GLFW. To attempt to build for Wayland, you need to install the `wayland libepoll-shim` packages and set the environment variable `PKG_CONFIG_PATH=/usr/pkg/libdata/pkgconfig`.
 	* On OpenBSD, you need the X11 sets. These are installed by default, and can be added from the ramdisk kernel at any time.
 	* See [here](http://www.glfw.org/docs/latest/compile.html#compile_deps) for full details.
 * Go 1.4+ is required on Windows (otherwise you must use MinGW v4.8.1 exactly, see [Go issue 8811](https://github.com/golang/go/issues/8811)).

--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -41,13 +41,13 @@ package glfw
 // BSD Build Tags
 // ----------------
 // GLFW Options:
-#cgo freebsd,!wayland openbsd pkg-config: x11 xau xcb xdmcp
-#cgo freebsd,wayland pkg-config: wayland-client wayland-cursor wayland-egl epoll-shim
-#cgo freebsd openbsd CFLAGS: -D_GLFW_HAS_DLOPEN
-#cgo freebsd,!wayland openbsd CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
-#cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND
+#cgo freebsd,!wayland netbsd,!wayland openbsd pkg-config: x11 xau xcb xdmcp
+#cgo freebsd,wayland netbsd,wayland pkg-config: wayland-client wayland-cursor wayland-egl epoll-shim
+#cgo freebsd netbsd openbsd CFLAGS: -D_GLFW_HAS_DLOPEN
+#cgo freebsd,!wayland netbsd,!wayland openbsd CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
+#cgo freebsd,wayland netbsd,wayland CFLAGS: -D_GLFW_WAYLAND
 
 // Linker Options:
-#cgo freebsd openbsd LDFLAGS: -lm
+#cgo freebsd netbsd openbsd LDFLAGS: -lm
 */
 import "C"

--- a/v3.3/glfw/c_glfw_bsd.go
+++ b/v3.3/glfw/c_glfw_bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd openbsd
+// +build freebsd netbsd openbsd
 
 package glfw
 

--- a/v3.3/glfw/native_linbsd.go
+++ b/v3.3/glfw/native_linbsd.go
@@ -1,4 +1,4 @@
-// +build linux,!wayland freebsd,!wayland openbsd
+// +build linux,!wayland freebsd,!wayland netbsd,!wayland openbsd
 
 package glfw
 


### PR DESCRIPTION
just add some missing build tags. helps with #288

should wayland build tags be included even if glfw upstream doesn't support netbsd's input system yet? and if so, should i keep the mention in the readme? either glfw supporting wscons or netbsd supporting evdev would make this build for wayland as is

as an example of updating a wayland application in such a way, Nia Alarie added wscons to swc with [a surprisingly small patchset](https://github.com/michaelforney/swc/commit/374e92246a19df53d4882d4ece39f31b4aabccee). so i think this would be easier than it might sound at first