### PR TITLE
Add a go.mod file for Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-gl/glfw
+
+go 1.12


### PR DESCRIPTION
This does not change a whole lot. It basically just makes it easier for the project to integrate with Go modules (such as using the replace directive in other modules to test out locally modified versions of this package) and allows tools to know the lowest targeted Go release for the project (useful for staticcheck and other tools when deciding on what checks to use).