### PR TITLE
v3.3/glfw: minor code cleanups

### DIFF
--- a/v3.3/glfw/input.go
+++ b/v3.3/glfw/input.go
@@ -409,7 +409,7 @@ func (w *Window) SetInputMode(mode InputMode, value int) {
 //
 // This function must only be called from the main thread.
 func RawMouseMotionSupported() bool {
-	return int(C.glfwRawMouseMotionSupported()) == int(True)
+	return int(C.glfwRawMouseMotionSupported()) == True
 }
 
 // GetKeyScancode function returns the platform-specific scancode of the

--- a/v3.3/glfw/util.go
+++ b/v3.3/glfw/util.go
@@ -6,10 +6,7 @@ package glfw
 import "C"
 
 func glfwbool(b C.int) bool {
-	if b == C.int(True) {
-		return true
-	}
-	return false
+	return b == C.int(True)
 }
 
 func bytes(origin []byte) (pointer *uint8, free func()) {


### PR DESCRIPTION
This removes an if-statement that was unnecessary and removes an unnecessary integer conversion.
This only touches the `v3.3/glfw` package because I don't have any good code to test the others with.