### PR TITLE
fix _GNU_SOURCE redefined warning

### DIFF
--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -26,8 +26,8 @@ package glfw
 // Linux Build Tags
 // ----------------
 // GLFW Options:
-#cgo linux,!wayland CFLAGS: -D_GLFW_X11 -D_GNU_SOURCE
-#cgo linux,wayland CFLAGS: -D_GLFW_WAYLAND -D_GNU_SOURCE
+#cgo linux,!wayland CFLAGS: -D_GLFW_X11
+#cgo linux,wayland CFLAGS: -D_GLFW_WAYLAND
 
 // Linker Options:
 #cgo linux,!gles1,!gles2,!gles3,!vulkan LDFLAGS: -lGL

--- a/v3.3/glfw/c_glfw_lin.go
+++ b/v3.3/glfw/c_glfw_lin.go
@@ -15,9 +15,9 @@ package glfw
 	#include "glfw/src/wayland-xdg-shell-client-protocol.c"
 #endif
 #ifdef _GLFW_X11
+	#include "glfw/src/x11_window.c"
 	#include "glfw/src/x11_init.c"
 	#include "glfw/src/x11_monitor.c"
-	#include "glfw/src/x11_window.c"
 	#include "glfw/src/glx_context.c"
 #endif
 #include "glfw/src/linux_joystick.c"

--- a/v3.3/glfw/glfw/src/x11_window.c
+++ b/v3.3/glfw/glfw/src/x11_window.c
@@ -27,9 +27,7 @@
 // It is fine to use C99 in this file because it will not be built with VS
 //========================================================================
 
-#if !defined(_GNU_SOURCE)
-  #define _GNU_SOURCE
-#endif
+#define _GNU_SOURCE
 
 #include "internal.h"
 

--- a/v3.3/glfw/glfw/src/x11_window.c
+++ b/v3.3/glfw/glfw/src/x11_window.c
@@ -27,7 +27,9 @@
 // It is fine to use C99 in this file because it will not be built with VS
 //========================================================================
 
-#define _GNU_SOURCE
+#if !defined(_GNU_SOURCE)
+  #define _GNU_SOURCE
+#endif
 
 #include "internal.h"
 


### PR DESCRIPTION
Closes #351

In upstream the _GNU_SOURCE and poll changes introduced this:

https://github.com/glfw/glfw/commit/9f73e9afa34b1c0902023d5d80be1c0f954135e5
https://github.com/glfw/glfw/commit/adc202d2c3182ca6ad8344624941e56d8e0bc493
