### PR TITLE
Address conflict between clang in osxcross and what latest MacOS SDK

### DIFF
--- a/v3.0/glfw/native_darwin.go
+++ b/v3.0/glfw/native_darwin.go
@@ -1,5 +1,6 @@
 package glfw
 
+//#define NS_FORMAT_ARGUMENT(A)
 //#define GLFW_EXPOSE_NATIVE_COCOA
 //#define GLFW_EXPOSE_NATIVE_NSGL
 //#include <GLFW/glfw3.h>

--- a/v3.0/glfw/native_windows.go
+++ b/v3.0/glfw/native_windows.go
@@ -1,5 +1,6 @@
 package glfw
 
+//#define NS_FORMAT_ARGUMENT(A)
 //#define GLFW_EXPOSE_NATIVE_WIN32
 //#define GLFW_EXPOSE_NATIVE_WGL
 //#define GLFW_INCLUDE_NONE

--- a/v3.1/glfw/cocoainit_darwin.go
+++ b/v3.1/glfw/cocoainit_darwin.go
@@ -2,6 +2,7 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#define NS_FORMAT_ARGUMENT(A)
 #ifdef _GLFW_COCOA
 	#include "glfw/src/cocoa_init.m"
 #endif

--- a/v3.1/glfw/cocoamonitor_darwin.go
+++ b/v3.1/glfw/cocoamonitor_darwin.go
@@ -2,6 +2,7 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#define NS_FORMAT_ARGUMENT(A)
 #ifdef _GLFW_COCOA
 	#include "glfw/src/cocoa_monitor.m"
 #endif

--- a/v3.1/glfw/cocoawindow_darwin.go
+++ b/v3.1/glfw/cocoawindow_darwin.go
@@ -2,6 +2,7 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#define NS_FORMAT_ARGUMENT(A)
 #ifdef _GLFW_COCOA
 	#include "glfw/src/cocoa_window.m"
 #endif

--- a/v3.1/glfw/glfw/src/internal.h
+++ b/v3.1/glfw/glfw/src/internal.h
@@ -56,6 +56,8 @@
  #error "No supported client library selected"
 #endif
 
+#define NS_FORMAT_ARGUMENT(A)
+
 // Disable the inclusion of the platform glext.h by gl.h to allow proper
 // inclusion of our own, newer glext.h below
 #define GL_GLEXT_LEGACY

--- a/v3.1/glfw/iokitjoystick_darwin.go
+++ b/v3.1/glfw/iokitjoystick_darwin.go
@@ -2,6 +2,7 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#define NS_FORMAT_ARGUMENT(A)
 #ifdef _GLFW_COCOA
 	#include "glfw/src/iokit_joystick.m"
 #endif

--- a/v3.1/glfw/native_darwin.go
+++ b/v3.1/glfw/native_darwin.go
@@ -1,6 +1,7 @@
 package glfw
 
 /*
+#define NS_FORMAT_ARGUMENT(A)
 #define GLFW_EXPOSE_NATIVE_COCOA
 #define GLFW_EXPOSE_NATIVE_NSGL
 #include "glfw/include/GLFW/glfw3.h"

--- a/v3.1/glfw/native_windows.go
+++ b/v3.1/glfw/native_windows.go
@@ -1,5 +1,6 @@
 package glfw
 
+//#define NS_FORMAT_ARGUMENT(A)
 //#define GLFW_EXPOSE_NATIVE_WIN32
 //#define GLFW_EXPOSE_NATIVE_WGL
 //#define GLFW_INCLUDE_NONE

--- a/v3.1/glfw/nsglcontext_darwin.go
+++ b/v3.1/glfw/nsglcontext_darwin.go
@@ -2,6 +2,7 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#define NS_FORMAT_ARGUMENT(A)
 #ifdef _GLFW_NSGL
 	#include "glfw/src/nsgl_context.m"
 #endif

--- a/v3.2/glfw/c_glfw_darwin.go
+++ b/v3.2/glfw/c_glfw_darwin.go
@@ -2,6 +2,7 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#define NS_FORMAT_ARGUMENT(A)
 #include "glfw/src/cocoa_init.m"
 #include "glfw/src/cocoa_joystick.m"
 #include "glfw/src/cocoa_monitor.m"

--- a/v3.2/glfw/glfw/src/internal.h
+++ b/v3.2/glfw/glfw/src/internal.h
@@ -45,6 +45,8 @@
  #error "You must not define any header option macros when compiling GLFW"
 #endif
 
+#define NS_FORMAT_ARGUMENT(A)
+
 #define GLFW_INCLUDE_NONE
 #include "../include/GLFW/glfw3.h"
 

--- a/v3.2/glfw/native_darwin.go
+++ b/v3.2/glfw/native_darwin.go
@@ -1,6 +1,7 @@
 package glfw
 
 /*
+#define NS_FORMAT_ARGUMENT(A)
 #define GLFW_EXPOSE_NATIVE_COCOA
 #define GLFW_EXPOSE_NATIVE_NSGL
 #include "glfw/include/GLFW/glfw3.h"

--- a/v3.2/glfw/native_windows.go
+++ b/v3.2/glfw/native_windows.go
@@ -1,5 +1,6 @@
 package glfw
 
+//#define NS_FORMAT_ARGUMENT(A)
 //#define GLFW_EXPOSE_NATIVE_WIN32
 //#define GLFW_EXPOSE_NATIVE_WGL
 //#define GLFW_INCLUDE_NONE

--- a/v3.3/glfw/c_glfw_darwin.go
+++ b/v3.3/glfw/c_glfw_darwin.go
@@ -2,6 +2,7 @@ package glfw
 
 /*
 #cgo CFLAGS: -x objective-c
+#define NS_FORMAT_ARGUMENT(A)
 #include "glfw/src/cocoa_init.m"
 #include "glfw/src/cocoa_joystick.m"
 #include "glfw/src/cocoa_monitor.m"

--- a/v3.3/glfw/glfw/src/internal.h
+++ b/v3.3/glfw/glfw/src/internal.h
@@ -45,6 +45,8 @@
  #error "You must not define any header option macros when compiling GLFW"
 #endif
 
+#define NS_FORMAT_ARGUMENT(A)
+
 #define GLFW_INCLUDE_NONE
 #include "../include/GLFW/glfw3.h"
 

--- a/v3.3/glfw/native_darwin.go
+++ b/v3.3/glfw/native_darwin.go
@@ -1,6 +1,7 @@
 package glfw
 
 /*
+#define NS_FORMAT_ARGUMENT(A)
 #define GLFW_EXPOSE_NATIVE_COCOA
 #define GLFW_EXPOSE_NATIVE_NSGL
 #include "glfw/include/GLFW/glfw3.h"

--- a/v3.3/glfw/native_windows.go
+++ b/v3.3/glfw/native_windows.go
@@ -1,5 +1,6 @@
 package glfw
 
+//#define NS_FORMAT_ARGUMENT(A)
 //#define GLFW_EXPOSE_NATIVE_WIN32
 //#define GLFW_EXPOSE_NATIVE_WGL
 //#define GLFW_INCLUDE_NONE


### PR DESCRIPTION
Latest MacOS SDK is using an attribute that confuse the clang provided by osxcross. As this attribute is just going to generate a warning at build time and seems to be of low value, getting rid of it seems like the easiest path forward that I can think of.