### PR TITLE
v3.3/glfw: remove 'immediately' from internal error message

### DIFF
--- a/v3.3/glfw/error.go
+++ b/v3.3/glfw/error.go
@@ -8,6 +8,7 @@ import "C"
 import (
 	"fmt"
 	"log"
+	"os"
 )
 
 // ErrorCode corresponds to an error code.
@@ -118,8 +119,8 @@ func goErrorCB(code C.int, desc *C.char) {
 	select {
 	case lastError <- err:
 	default:
-		fmt.Println("GLFW: An uncaught error has occurred:", err)
-		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
+		fmt.Fprintln(os.Stderr, "go-gl/glfw: internal error: an uncaught error has occurred:", err)
+		fmt.Fprintln(os.Stderr, "go-gl/glfw: Please report this in the Go package issue tracker.")
 	}
 }
 
@@ -134,8 +135,8 @@ func init() {
 func flushErrors() {
 	err := fetchError()
 	if err != nil {
-		fmt.Println("GLFW: An uncaught error has occurred:", err)
-		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
+		fmt.Fprintln(os.Stderr, "go-gl/glfw: internal error: an uncaught error has occurred:", err)
+		fmt.Fprintln(os.Stderr, "go-gl/glfw: Please report this in the Go package issue tracker.")
 	}
 }
 
@@ -172,8 +173,8 @@ func acceptError(codes ...ErrorCode) error {
 	case notInitialized, noCurrentContext, invalidEnum, invalidValue, outOfMemory:
 		panic(err)
 	default:
-		fmt.Println("GLFW: An invalid error was not accepted by the caller:", err)
-		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
+		fmt.Fprintln(os.Stderr, "go-gl/glfw: internal error: an invalid error was not accepted by the caller:", err)
+		fmt.Fprintln(os.Stderr, "go-gl/glfw: Please report this in the Go package issue tracker.")
 		panic(err)
 	}
 }


### PR DESCRIPTION
An internal error is an error that should never happen, but it can still happen when there is a bug in the code. When it happens, glfw prints a suggestion of reporting the bug, as that way we can learn about the bug and fix it.

The word "immediately" may create a sense of urgency, but in fact these bug reports are not very time sensitive, at least no more than any other issue. Relax the language a bit.

Also, as commonly done, print these errors to stderr rather than stdout.