### PR TITLE
v3.3/glfw: handle GLFW_NO_WINDOW_CONTEXT error

### DIFF
--- a/v3.3/glfw/error.go
+++ b/v3.3/glfw/error.go
@@ -23,6 +23,7 @@ const (
 	invalidValue     ErrorCode = C.GLFW_INVALID_VALUE      // One of the parameters for the function was given an invalid value.
 	outOfMemory      ErrorCode = C.GLFW_OUT_OF_MEMORY      // A memory allocation failed.
 	platformError    ErrorCode = C.GLFW_PLATFORM_ERROR     // A platform-specific error occurred that does not match any of the more specific categories.
+	noWindowContext  ErrorCode = C.GLFW_NO_WINDOW_CONTEXT  // A window that does not have an OpenGL or OpenGL ES context was passed to a function that requires it to have one.
 )
 
 const (
@@ -84,6 +85,8 @@ func (e ErrorCode) String() string {
 		return "OutOfMemory"
 	case platformError:
 		return "PlatformError"
+	case noWindowContext:
+		return "NoWindowContext"
 	case APIUnavailable:
 		return "APIUnavailable"
 	case VersionUnavailable:
@@ -170,7 +173,7 @@ func acceptError(codes ...ErrorCode) error {
 	case platformError:
 		log.Println(err)
 		return nil
-	case notInitialized, noCurrentContext, invalidEnum, invalidValue, outOfMemory:
+	case notInitialized, noCurrentContext, invalidEnum, invalidValue, outOfMemory, noWindowContext:
 		panic(err)
 	default:
 		fmt.Fprintln(os.Stderr, "go-gl/glfw: internal error: an invalid error was not accepted by the caller:", err)


### PR DESCRIPTION
The `GLFW_NO_WINDOW_CONTEXT` error code happens when a window without a context is passed to a function that [requires it to have one](https://www.glfw.org/docs/latest/group__errors.html#gacff24d2757da752ae4c80bf452356487). This is deemed a programmer mistake, something that this Go package currently handles by loudly panicking so the mistake is fixed sooner.

Apply the same treatment to this error, which was previously missed and resulted in a "please report this in the Go package issue tracker" message being printed alongside the panic.

Fixes #389.