### PR TITLE
Remove warning/errors about undefined functions

### DIFF
--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -26,7 +26,7 @@ package glfw
 // Linux Build Tags
 // ----------------
 // GLFW Options:
-#cgo linux,!wayland CFLAGS: -D_GLFW_X11 -D_GNU_SOURCE
+#cgo linux,!wayland CFLAGS: -D_GLFW_X11
 #cgo linux,wayland CFLAGS: -D_GLFW_WAYLAND -D_GNU_SOURCE
 
 // Linker Options:

--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -26,8 +26,8 @@ package glfw
 // Linux Build Tags
 // ----------------
 // GLFW Options:
-#cgo linux,!wayland CFLAGS: -D_GLFW_X11
-#cgo linux,wayland CFLAGS: -D_GLFW_WAYLAND
+#cgo linux,!wayland CFLAGS: -D_GLFW_X11 -D_GNU_SOURCE
+#cgo linux,wayland CFLAGS: -D_GLFW_WAYLAND -D_GNU_SOURCE
 
 // Linker Options:
 #cgo linux,!gles1,!gles2,!gles3,!vulkan LDFLAGS: -lGL


### PR DESCRIPTION
Fixes #359

features.h needs `_GNU_SOURCE` to be set to allow stdlib.h to declare the functions.